### PR TITLE
Add My Stack subscription replacement planner

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24,6 +24,12 @@
     toastTimer = setTimeout(() => el.classList.remove('show'), 2400);
   };
 
+  window.CanIVibecodeIt = {
+    ...(window.CanIVibecodeIt || {}),
+    toast,
+    track,
+  };
+
   /* ---------- theme toggle ---------- */
   $('[data-toggle-theme]')?.addEventListener('click', () => {
     const next = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light';
@@ -68,7 +74,7 @@
      nobody has to scroll past the ticker to see what matched. */
   const srBox = $('#search-results');
   const rowData = rows.map((r) => ({
-    href: r.getAttribute('href'),
+    href: $('.row-link', r)?.getAttribute('href'),
     name: $('.name', r)?.textContent ?? '',
     lower: r.dataset.name,
     verdict: r.dataset.verdict,
@@ -293,6 +299,19 @@
     return ok;
   };
 
+  const launchAgent = (agentId, prompt) => {
+    const agent = AGENTS[agentId];
+    if (!agent) return false;
+    copyText(prompt);
+    toast(`opening ${agent.name} · prompt prefilled (and copied, just in case)`);
+    const url = agent.link(prompt);
+    if (agent.newTab) window.open(url, '_blank', 'noopener');
+    else window.location.href = url;
+    return true;
+  };
+
+  Object.assign(window.CanIVibecodeIt, { copyText, launchAgent });
+
   const flashCopied = (btn, text = 'copied ✓') => {
     const label = $('span:last-child', btn);
     const original = label.textContent;
@@ -322,13 +341,8 @@
         return;
       }
 
-      const agent = AGENTS[btn.dataset.agent];
-      copyText(prompt); // best-effort backup; don't block the deeplink on it
       flashCopied(btn, 'opening…');
-      toast(`opening ${agent.name} · prompt prefilled (and copied, just in case)`);
-      const url = agent.link(prompt);
-      if (agent.newTab) window.open(url, '_blank', 'noopener');
-      else window.location.href = url;
+      launchAgent(btn.dataset.agent, prompt);
       track('copy_prompt', { app: slug, agent: btn.dataset.agent });
     });
   });

--- a/public/js/stack-page.js
+++ b/public/js/stack-page.js
@@ -1,0 +1,551 @@
+/* /stack mission-control rendering and interactions. */
+(() => {
+  const root = document.querySelector('#stack-mission-control');
+  if (!root) return;
+
+  const apps = (() => {
+    try {
+      return JSON.parse(document.querySelector('#stack-app-data')?.textContent || '[]');
+    } catch {
+      return [];
+    }
+  })();
+  const appsBySlug = new Map(apps.map((app) => [app.slug, app]));
+  const esc = (value) =>
+    String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
+  const usd = (value) =>
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 2,
+    }).format(value);
+  const monthly = (item) =>
+    window.StackPlannerLogic.numericPrice(item) ? `${usd(item.priceMonthly)}/mo` : 'varies';
+  const annual = (item) =>
+    window.StackPlannerLogic.numericPrice(item) ? `${usd(item.priceMonthly * 12)}/year` : null;
+  const compromise = (item) =>
+    item.whatYouLose?.[0] || item.verdictSummary || 'The original product may still have useful polish.';
+  const statusLabel = (status) =>
+    ({ targeted: 'TARGETED', building: 'BUILDING', replaced: 'REPLACED', keeping: 'KEEPING' })[
+      status
+    ] || status;
+  const civci = () => window.CanIVibecodeIt || {};
+
+  let currentItems = [];
+  let currentRoadmap = null;
+  let currentMetrics = null;
+
+  const storageMessage = () => {
+    const note = document.querySelector('[data-stack-storage-note]');
+    if (!note || !window.MyStack) return;
+    const issue = window.MyStack.getIssue();
+    const available = window.MyStack.isAvailable();
+    if (!available) {
+      note.hidden = false;
+      note.textContent =
+        'LOCAL STORAGE UNAVAILABLE · changes work for this page, but cannot survive a reload.';
+    } else if (issue === 'malformed' || issue === 'unknown-version') {
+      note.hidden = false;
+      note.textContent =
+        'MISSION FILE COULD NOT BE READ · an empty, safe stack is shown instead.';
+    } else if (issue === 'discarded-items') {
+      note.hidden = false;
+      note.textContent =
+        'MISSION FILE REPAIRED · unavailable apps or invalid entries were removed.';
+    } else {
+      note.hidden = true;
+      note.textContent = '';
+    }
+  };
+
+  const statusControl = (item) => `
+    <div class="stack-status-control">
+      <label class="microlabel" for="stack-status-${esc(item.slug)}">STATUS</label>
+      <select id="stack-status-${esc(item.slug)}" data-stack-status data-slug="${esc(item.slug)}">
+        ${['targeted', 'building', 'replaced', 'keeping']
+          .map(
+            (status) =>
+              `<option value="${status}"${item.status === status ? ' selected' : ''}>${statusLabel(
+                status
+              )}</option>`
+          )
+          .join('')}
+      </select>
+      <button class="stack-remove" type="button" data-stack-remove="${esc(
+        item.slug
+      )}" aria-label="Remove ${esc(item.name)} from My Stack">REMOVE</button>
+    </div>`;
+
+  const promptActions = (item, recommended = false) => {
+    if (!item.prompt) {
+      return `<p class="stack-no-prompt">NO CURATED PROMPT AVAILABLE · view the honest build plan.</p>`;
+    }
+    return `
+      <div class="stack-prompt-actions" role="group" aria-label="Build actions for ${esc(item.name)}">
+        <a class="stack-action" href="/${esc(item.slug)}#build-plan">${
+          recommended ? 'VIEW BUILD PLAN' : 'VIEW PROMPT'
+        }</a>
+        <button class="stack-action" type="button" data-copy-prompt="${esc(
+          item.slug
+        )}">COPY PROMPT</button>
+        <button class="stack-action" type="button" data-launch-agent="cursor" data-slug="${esc(
+          item.slug
+        )}">OPEN IN CURSOR</button>
+        <button class="stack-action" type="button" data-launch-agent="codex" data-slug="${esc(
+          item.slug
+        )}">OPEN IN CODEX</button>
+        <button class="stack-action" type="button" data-launch-agent="claude-code" data-slug="${esc(
+          item.slug
+        )}">OPEN IN CLAUDE CODE</button>
+      </div>`;
+  };
+
+  const itemCard = (item, phaseId, actionable = false) => {
+    const reason = currentRoadmap.reasonFor(item, phaseId);
+    const annualPrice = annual(item);
+    return `
+      <article class="stack-item" data-roadmap-item="${esc(item.slug)}">
+        <div class="stack-item-main">
+          <div class="stack-item-title">
+            <img src="/icons/${esc(item.slug)}.png" width="38" height="38" alt="">
+            <div>
+              <h3><a href="/${esc(item.slug)}">${esc(item.name)}</a></h3>
+              <p>${esc(item.categoryEmoji)} ${esc(item.categoryLabel)} · ${esc(
+                monthly(item)
+              )}${annualPrice ? ` · ${esc(annualPrice)}` : ''}</p>
+            </div>
+          </div>
+          <div class="stack-item-badges">
+            <span class="badge ${esc(item.verdict)}">${esc(item.verdictLabel)}</span>
+            <span class="status-badge status-${esc(item.status)}">${esc(
+              statusLabel(item.status)
+            )}</span>
+          </div>
+        </div>
+        <div class="stack-item-brief">
+          <span class="roadmap-reason">${esc(reason)}</span>
+          <span>${esc(item.diyTimeEstimate)}</span>
+          <p><b>PRINCIPAL COMPROMISE:</b> ${esc(compromise(item))}</p>
+        </div>
+        ${actionable ? promptActions(item) : ''}
+        ${statusControl(item)}
+      </article>`;
+  };
+
+  const phaseSection = (phase) => {
+    if (!phase.items.length) return '';
+    return `
+      <section class="roadmap-phase" aria-labelledby="phase-${esc(phase.id)}">
+        <div class="roadmap-phase-head">
+          <span class="phase-index">${String(phase.items.length).padStart(2, '0')}</span>
+          <div>
+            <h2 id="phase-${esc(phase.id)}">${esc(phase.title)}</h2>
+            <p>${esc(phase.description)}</p>
+          </div>
+        </div>
+        <div class="stack-item-list">
+          ${phase.items.map((item) => itemCard(item, phase.id, true)).join('')}
+        </div>
+      </section>`;
+  };
+
+  const metric = (label, value, note, tone = '') => `
+    <article class="stack-metric ${tone}">
+      <span class="microlabel">${esc(label)}</span>
+      <strong>${esc(value)}</strong>
+      <p>${esc(note)}</p>
+    </article>`;
+
+  const effortCopy = (metrics) => {
+    const labels = {
+      'one sitting': ['one-sitting build', 'one-sitting builds'],
+      weekend: ['weekend mission', 'weekend missions'],
+      'multi-day': ['multi-day project', 'multi-day projects'],
+      'not realistically solo': ['not realistically solo', 'not realistically solo'],
+    };
+    const parts = Object.entries(metrics.effort)
+      .filter(([, count]) => count > 0)
+      .map(([key, count]) => `${count} ${labels[key][count === 1 ? 0 : 1]}`);
+    return parts.length ? parts.join(' · ') : 'No remaining build workload';
+  };
+
+  const summarySection = (metrics) => `
+    <section class="stack-summary" aria-labelledby="stack-summary-title">
+      <div class="section-command">
+        <span class="terminal-prompt">&gt;</span>
+        <h2 id="stack-summary-title">CURRENT BURN + RECOVERY</h2>
+      </div>
+      <div class="stack-metrics-grid">
+        ${metric(
+          'ORIGINAL STACK COST',
+          `${usd(metrics.originalMonthly)}/mo`,
+          `${usd(metrics.originalAnnual)}/year baseline`
+        )}
+        ${metric(
+          'CURRENT REMAINING SPEND',
+          `${usd(metrics.remainingMonthly)}/mo`,
+          'Targeted, building, and keeping'
+        )}
+        ${metric(
+          'REALISED SAVINGS',
+          `${usd(metrics.realisedMonthly)}/mo`,
+          `${usd(metrics.realisedAnnual)}/year avoided`,
+          'positive'
+        )}
+        ${metric(
+          'IMMEDIATELY RECOVERABLE · YES',
+          `${usd(metrics.immediateMonthly)}/mo`,
+          'Targeted or building YES opportunities',
+          'positive'
+        )}
+        ${metric(
+          'CONDITIONAL · KINDA',
+          `${usd(metrics.conditionalMonthly)}/mo`,
+          'Potential only · real compromises remain',
+          'conditional'
+        )}
+        ${metric(
+          'PROBABLY KEEP',
+          `${usd(metrics.probablyKeepMonthly)}/mo`,
+          'NOT REALLY targets and anything you chose to keep'
+        )}
+      </div>
+      <div class="stack-progress-panel">
+        <div>
+          <span class="microlabel">REPLACEMENT PROGRESS</span>
+          <strong>${metrics.counts.replaced} of ${metrics.counts.total} subscriptions eliminated</strong>
+          <p>${metrics.counts.targeted} targeted · ${metrics.counts.building} building · ${
+            metrics.counts.replaced
+          } replaced · ${metrics.counts.keeping} keeping</p>
+        </div>
+        <div>
+          <span class="microlabel">REMAINING BUILD EFFORT</span>
+          <strong>${esc(effortCopy(metrics))}</strong>
+          <p>Effort bands stay separate. They are not fake hour estimates.</p>
+        </div>
+      </div>
+      ${
+        metrics.variableCount
+          ? `<p class="variable-note">${metrics.variableCount} variable-price ${
+              metrics.variableCount === 1 ? 'product was' : 'products were'
+            } excluded from every dollar total because the repository lists the price as “varies”.</p>`
+          : ''
+      }
+    </section>`;
+
+  const recommendationSection = (item) => {
+    if (!item) {
+      const fullyReplaced = currentMetrics.counts.replaced === currentMetrics.counts.total;
+      return `
+        <section class="recommendation empty-recommendation">
+          <span class="microlabel">${fullyReplaced ? 'MISSION COMPLETE' : 'NO ACTIONABLE TARGET'}</span>
+          <h2>${fullyReplaced ? 'EVERY SUBSCRIPTION ELIMINATED' : 'THE MOAT SURVIVES'}</h2>
+          <p>${
+            fullyReplaced
+              ? `${usd(currentMetrics.realisedMonthly)}/mo eliminated · ${usd(
+                  currentMetrics.realisedAnnual
+                )}/year avoided.`
+              : 'Everything remaining is marked KEEPING or is not an honest economic build target.'
+          }</p>
+        </section>`;
+    }
+    const reason =
+      item.status === 'building'
+        ? 'This is already in progress. Resume it before opening another front.'
+        : currentRoadmap.reasonFor(
+            item,
+            currentRoadmap.phases.find((phase) => phase.items.includes(item))?.id || 'longer'
+          ) === 'ONE-SITTING WIN'
+          ? 'Strong YES verdict, one-sitting effort, and the best recoverable cost among comparable targets.'
+          : 'This is the first eligible target after effort, verdict, monthly cost, and name are applied in order.';
+    return `
+      <section class="recommendation" aria-labelledby="recommended-target-title">
+        <span class="microlabel">${
+          item.status === 'building' ? 'ACTIVE MISSION' : 'RECOMMENDED NEXT TARGET'
+        }</span>
+        <div class="recommendation-grid">
+          <div class="recommendation-title">
+            <img src="/icons/${esc(item.slug)}.png" width="52" height="52" alt="">
+            <div>
+              <h2 id="recommended-target-title">${esc(item.name)}</h2>
+              <p>${esc(monthly(item))}${
+                annual(item) ? ` · ${esc(annual(item))}` : ''
+              } · ${esc(item.verdictLabel)} · ${esc(item.diyTimeEstimate)}</p>
+            </div>
+          </div>
+          <div class="recommendation-copy">
+            <p><b>WHY THIS ONE:</b> ${esc(reason)}</p>
+            <p><b>PRINCIPAL COMPROMISE:</b> ${esc(compromise(item))}</p>
+          </div>
+        </div>
+        ${promptActions(item, true)}
+      </section>`;
+  };
+
+  const roadmapControls = () => {
+    const hasActions = currentRoadmap.actionableOrder.some((item) => item.prompt);
+    return `
+      <div class="roadmap-command-bar">
+        <div>
+          <span class="microlabel">PROMPT COMMAND CENTRE</span>
+          <p>Package the plan or launch the repository’s original curated prompts.</p>
+        </div>
+        <div class="stack-prompt-actions">
+          <button class="stack-action" type="button" data-copy-roadmap${
+            currentRoadmap.actionableOrder.length ? '' : ' disabled'
+          }>COPY ACTIONABLE ROADMAP</button>
+          <button class="stack-action" type="button" data-copy-all-prompts${
+            hasActions ? '' : ' disabled'
+          }>COPY ALL BUILD PROMPTS</button>
+        </div>
+      </div>`;
+  };
+
+  const roadmapSection = () => `
+    <section class="escape-plan" aria-labelledby="escape-plan-title">
+      <div class="escape-plan-head">
+        <span class="microlabel">DETERMINISTIC · HONEST · LOCAL</span>
+        <h2 id="escape-plan-title">YOUR VIBECODING ESCAPE PLAN</h2>
+        <p>
+          Lower effort comes first, then stronger verdict, higher monthly cost, and app name.
+          Conditional savings are never treated as guaranteed.
+        </p>
+      </div>
+      ${roadmapControls()}
+      ${recommendationSection(currentRoadmap.recommendation)}
+      ${
+        currentRoadmap.active.length
+          ? `<section class="roadmap-phase active-phase" aria-labelledby="active-mission-title">
+              <div class="roadmap-phase-head">
+                <span class="phase-index">▶</span>
+                <div>
+                  <h2 id="active-mission-title">ACTIVE MISSION</h2>
+                  <p>Resume the build already underway before starting another.</p>
+                </div>
+              </div>
+              <div class="stack-item-list">
+                ${currentRoadmap.active
+                  .map((item) => itemCard(item, 'active', true))
+                  .join('')}
+              </div>
+            </section>`
+          : ''
+      }
+      ${
+        currentRoadmap.missionComplete.length
+          ? `<section class="roadmap-phase mission-complete" aria-labelledby="mission-complete-title">
+              <div class="roadmap-phase-head">
+                <span class="phase-index">✓</span>
+                <div>
+                  <h2 id="mission-complete-title">MISSION COMPLETE</h2>
+                  <p>${usd(
+                    window.StackPlannerLogic.sumPrices(currentRoadmap.missionComplete)
+                  )}/mo eliminated · ${usd(
+                    window.StackPlannerLogic.sumPrices(currentRoadmap.missionComplete) * 12
+                  )}/year avoided.</p>
+                </div>
+              </div>
+              <div class="stack-item-list">
+                ${currentRoadmap.missionComplete
+                  .map((item) => itemCard(item, 'complete', false))
+                  .join('')}
+              </div>
+            </section>`
+          : ''
+      }
+      ${currentRoadmap.phases.map(phaseSection).join('')}
+      ${
+        currentRoadmap.keep.length
+          ? `<section class="roadmap-phase keep-phase" aria-labelledby="probably-keep-title">
+              <div class="roadmap-phase-head">
+                <span class="phase-index">×</span>
+                <div>
+                  <h2 id="probably-keep-title">PROBABLY KEEP // THE MOAT SURVIVES</h2>
+                  <p>Building these is not the economic win. Keeping a useful product is a valid decision.</p>
+                </div>
+              </div>
+              <div class="stack-item-list">
+                ${currentRoadmap.keep
+                  .map((item) => itemCard(item, 'keep', false))
+                  .join('')}
+              </div>
+            </section>`
+          : ''
+      }
+    </section>`;
+
+  const emptyState = () => `
+    <section class="stack-empty">
+      <span class="microlabel">NO TARGETS ACQUIRED</span>
+      <h2>YOUR MISSION FILE IS EMPTY</h2>
+      <p>
+        Add the subscriptions you currently use from the death list. Their prices, verdicts,
+        build estimates, compromises, and original prompts stay synced to the repository.
+      </p>
+      <a class="btn primary" href="/#death-list">BROWSE THE DEATH LIST</a>
+    </section>`;
+
+  const render = (state, announcement = '') => {
+    if (!window.StackPlannerLogic) return;
+    currentItems = window.StackPlannerLogic.hydrate(state, apps);
+    currentMetrics = window.StackPlannerLogic.calculate(currentItems);
+    currentRoadmap = window.StackPlannerLogic.buildRoadmap(currentItems);
+
+    const title = document.querySelector('[data-stack-page-title]');
+    if (title) {
+      title.textContent = `YOUR STACK // ${currentMetrics.counts.total} ${
+        currentMetrics.counts.total === 1 ? 'TARGET' : 'TARGETS'
+      }`;
+    }
+    storageMessage();
+    root.innerHTML = currentItems.length
+      ? `${summarySection(currentMetrics)}${roadmapSection()}`
+      : emptyState();
+    window.MyStack?.refreshControls();
+    const live = document.querySelector('[data-stack-live]');
+    if (live && announcement) live.textContent = announcement;
+  };
+
+  const phaseFor = (item) => {
+    if (currentRoadmap.active.includes(item)) return 'ACTIVE MISSION';
+    const phase = currentRoadmap.phases.find((entry) => entry.items.includes(item));
+    return phase?.title || 'ACTIONABLE';
+  };
+
+  const roadmapText = () => {
+    const sections = [];
+    if (currentRoadmap.active.length) {
+      sections.push(['ACTIVE MISSION', currentRoadmap.active]);
+    }
+    currentRoadmap.phases.forEach((phase) => {
+      if (phase.items.length) sections.push([phase.title, phase.items]);
+    });
+    return [
+      'YOUR VIBECODING ESCAPE PLAN',
+      '',
+      ...sections.flatMap(([title, items]) => [
+        title,
+        ...items.flatMap((item) => [
+          `${item.name} · ${monthly(item)} · ${item.verdictLabel} · ${item.diyTimeEstimate}`,
+          `What you lose: ${compromise(item)}`,
+          `${location.origin}/${item.slug}`,
+          '',
+        ]),
+      ]),
+    ].join('\n').trim();
+  };
+
+  const allPromptsText = () =>
+    currentRoadmap.actionableOrder
+      .filter((item) => item.prompt)
+      .map(
+        (item) =>
+          `${phaseFor(item)}\n${item.name.toUpperCase()} · ${monthly(item)} · ${
+            item.verdictLabel
+          } · ${item.diyTimeEstimate}\n${location.origin}/${item.slug}\n\n${item.prompt}`
+      )
+      .join('\n\n========================================\n\n');
+
+  const copyWithFeedback = async (button, text, success) => {
+    const ok = await civci().copyText?.(text);
+    civci().toast?.(ok ? success : 'copy failed · select the text manually');
+    if (!ok) return;
+    const original = button.textContent;
+    button.textContent = 'COPIED ✓';
+    window.setTimeout(() => {
+      button.textContent = original;
+    }, 1800);
+  };
+
+  root.addEventListener('change', (event) => {
+    const select = event.target.closest('[data-stack-status]');
+    if (!select) return;
+    const item = appsBySlug.get(select.dataset.slug);
+    const status = select.value;
+    if (!item || !window.MyStack?.setStatus(item.slug, status)) return;
+
+    let message = `${item.name} marked ${status}`;
+    if (status === 'building') message = `MISSION STARTED · ${item.name}`;
+    if (status === 'replaced') {
+      message =
+        typeof item.priceMonthly === 'number'
+          ? `SUBSCRIPTION ELIMINATED · ${usd(item.priceMonthly)}/mo removed · ${usd(
+              item.priceMonthly * 12
+            )}/year avoided`
+          : `SUBSCRIPTION ELIMINATED · ${item.name} removed · variable price`;
+    }
+    if (status === 'keeping') message = `TARGET WITHDRAWN · KEEPING ${item.name}`;
+    civci().toast?.(message);
+    civci().track?.('stack_status', { app: item.slug, status });
+  });
+
+  root.addEventListener('click', async (event) => {
+    const remove = event.target.closest('[data-stack-remove]');
+    if (remove) {
+      const item = appsBySlug.get(remove.dataset.stackRemove);
+      if (item && window.MyStack?.remove(item.slug)) {
+        civci().toast?.(`${item.name} removed from your stack`);
+        civci().track?.('stack_remove', { app: item.slug, source: 'stack_page' });
+      }
+      return;
+    }
+
+    const copyPrompt = event.target.closest('[data-copy-prompt]');
+    if (copyPrompt) {
+      const item = appsBySlug.get(copyPrompt.dataset.copyPrompt);
+      if (item) {
+        await copyWithFeedback(
+          copyPrompt,
+          item.prompt,
+          `prompt copied · ${item.name} is ready to build`
+        );
+        civci().track?.('copy_prompt', { app: item.slug, agent: 'raw', source: 'stack' });
+      }
+      return;
+    }
+
+    const launch = event.target.closest('[data-launch-agent]');
+    if (launch) {
+      const item = appsBySlug.get(launch.dataset.slug);
+      if (item) {
+        civci().launchAgent?.(launch.dataset.launchAgent, item.prompt);
+        civci().track?.('copy_prompt', {
+          app: item.slug,
+          agent: launch.dataset.launchAgent,
+          source: 'stack',
+        });
+      }
+      return;
+    }
+
+    const copyRoadmap = event.target.closest('[data-copy-roadmap]');
+    if (copyRoadmap) {
+      await copyWithFeedback(copyRoadmap, roadmapText(), 'actionable roadmap copied');
+      civci().track?.('stack_copy_roadmap');
+      return;
+    }
+
+    const copyAll = event.target.closest('[data-copy-all-prompts]');
+    if (copyAll) {
+      await copyWithFeedback(copyAll, allPromptsText(), 'all build prompts copied');
+      civci().track?.('stack_copy_all_prompts');
+    }
+  });
+
+  document.addEventListener('stack:ready', (event) => render(event.detail.state));
+  document.addEventListener('stack:changed', (event) => {
+    const name = appsBySlug.get(event.detail.slug)?.name || 'Stack';
+    const announcement =
+      event.detail.action === 'status'
+        ? `${name} status updated. Savings and roadmap recalculated.`
+        : `${name} updated. Stack totals and roadmap recalculated.`;
+    render(event.detail.state, announcement);
+  });
+
+  if (window.MyStack) render(window.MyStack.getState());
+})();

--- a/public/js/stack-planner.js
+++ b/public/js/stack-planner.js
@@ -1,0 +1,165 @@
+/* Pure My Stack calculations and deterministic roadmap generation. */
+(() => {
+  const EFFORT_ORDER = {
+    'one sitting': 0,
+    weekend: 1,
+    'multi-day': 2,
+    'not realistically solo': 3,
+  };
+  const VERDICT_ORDER = { yes: 0, kinda: 1, no: 2 };
+  const STATUS_ORDER = { targeted: 0, building: 0, replaced: 1, keeping: 2 };
+
+  const numericPrice = (item) =>
+    typeof item.priceMonthly === 'number' && Number.isFinite(item.priceMonthly);
+
+  const sumPrices = (items) =>
+    items.reduce((sum, item) => sum + (numericPrice(item) ? item.priceMonthly : 0), 0);
+
+  const compareItems = (a, b) =>
+    (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9) ||
+    (EFFORT_ORDER[a.diyTimeEstimate] ?? 9) - (EFFORT_ORDER[b.diyTimeEstimate] ?? 9) ||
+    (VERDICT_ORDER[a.verdict] ?? 9) - (VERDICT_ORDER[b.verdict] ?? 9) ||
+    (numericPrice(b) ? b.priceMonthly : -1) - (numericPrice(a) ? a.priceMonthly : -1) ||
+    a.name.localeCompare(b.name);
+
+  const hydrate = (state, apps) => {
+    const bySlug = new Map(apps.map((app) => [app.slug, app]));
+    return (state?.items || [])
+      .map((saved) => {
+        const app = bySlug.get(saved.slug);
+        return app ? { ...app, ...saved } : null;
+      })
+      .filter(Boolean);
+  };
+
+  const calculate = (items) => {
+    const selected = items;
+    const live = items.filter((item) => item.status !== 'replaced');
+    const actionable = items.filter(
+      (item) => item.status === 'targeted' || item.status === 'building'
+    );
+    const realised = items.filter((item) => item.status === 'replaced');
+    const probablyKeep = live.filter(
+      (item) => item.status === 'keeping' || item.verdict === 'no'
+    );
+    const counts = {
+      total: items.length,
+      targeted: items.filter((item) => item.status === 'targeted').length,
+      building: items.filter((item) => item.status === 'building').length,
+      replaced: realised.length,
+      keeping: items.filter((item) => item.status === 'keeping').length,
+    };
+
+    const effort = {
+      'one sitting': actionable.filter((item) => item.diyTimeEstimate === 'one sitting').length,
+      weekend: actionable.filter((item) => item.diyTimeEstimate === 'weekend').length,
+      'multi-day': actionable.filter((item) => item.diyTimeEstimate === 'multi-day').length,
+      'not realistically solo': actionable.filter(
+        (item) => item.diyTimeEstimate === 'not realistically solo'
+      ).length,
+    };
+
+    return {
+      originalMonthly: sumPrices(selected),
+      originalAnnual: sumPrices(selected) * 12,
+      remainingMonthly: sumPrices(live),
+      realisedMonthly: sumPrices(realised),
+      realisedAnnual: sumPrices(realised) * 12,
+      immediateMonthly: sumPrices(actionable.filter((item) => item.verdict === 'yes')),
+      conditionalMonthly: sumPrices(actionable.filter((item) => item.verdict === 'kinda')),
+      probablyKeepMonthly: sumPrices(probablyKeep),
+      variableCount: selected.filter((item) => !numericPrice(item)).length,
+      counts,
+      effort,
+    };
+  };
+
+  const reasonFor = (item, phase) => {
+    if (item.status === 'keeping') return 'USER CHOSE TO KEEP';
+    if (item.diyTimeEstimate === 'not realistically solo') return 'NOT REALISTICALLY SOLO';
+    if (item.verdict === 'no') {
+      return /network|data/i.test(item.moatType || '') ? 'NETWORK/DATA MOAT' : 'THE MOAT SURVIVES';
+    }
+    if (phase === 'quick') return 'ONE-SITTING WIN';
+    if (phase === 'weekend') {
+      return item.verdict === 'kinda' ? 'REAL GAPS REMAIN' : 'WEEKEND BUILD';
+    }
+    if (item.diyTimeEstimate === 'multi-day') return 'MULTI-DAY PROJECT';
+    return 'REAL GAPS REMAIN';
+  };
+
+  const buildRoadmap = (items) => {
+    const sorted = [...items].sort(compareItems);
+    const missionComplete = sorted.filter((item) => item.status === 'replaced');
+    const active = sorted.filter((item) => item.status === 'building');
+    const untouched = sorted.filter((item) => item.status === 'targeted');
+
+    const probablyKeep = sorted.filter(
+      (item) =>
+        item.status !== 'replaced' &&
+        item.status !== 'keeping' &&
+        (item.verdict === 'no' || item.diyTimeEstimate === 'not realistically solo')
+    );
+    const eligible = untouched.filter((item) => !probablyKeep.includes(item));
+    const quick = eligible.filter(
+      (item) => item.verdict === 'yes' && item.diyTimeEstimate === 'one sitting'
+    );
+    const weekend = eligible.filter(
+      (item) =>
+        (item.verdict === 'yes' && item.diyTimeEstimate === 'weekend') ||
+        (item.verdict === 'kinda' &&
+          (item.diyTimeEstimate === 'one sitting' || item.diyTimeEstimate === 'weekend'))
+    );
+    const longer = eligible.filter(
+      (item) => !quick.includes(item) && !weekend.includes(item)
+    );
+    const keeping = sorted.filter((item) => item.status === 'keeping');
+    const keep = [...probablyKeep, ...keeping].sort(compareItems);
+
+    const phases = [
+      {
+        id: 'quick',
+        title: 'PHASE 1 // QUICK WINS',
+        description: 'The best subscriptions to attack first: high confidence and low effort.',
+        items: quick,
+      },
+      {
+        id: 'weekend',
+        title: 'PHASE 2 // WEEKEND MISSIONS',
+        description:
+          'Actionable builds with more moving parts. KINDA targets will involve real compromises.',
+        items: weekend,
+      },
+      {
+        id: 'longer',
+        title: 'PHASE 3 // LONGER BUILDS + CAREFUL DECISIONS',
+        description:
+          'Meaningful projects where polish, integrations, sync, or collaboration may still justify the original.',
+        items: longer,
+      },
+    ];
+
+    const actionableOrder = [...active, ...phases.flatMap((phase) => phase.items)];
+    const recommendation =
+      phases.flatMap((phase) => phase.items)[0] || active[0] || null;
+
+    return {
+      missionComplete,
+      active,
+      phases,
+      keep,
+      actionableOrder,
+      recommendation,
+      reasonFor,
+    };
+  };
+
+  window.StackPlannerLogic = {
+    hydrate,
+    calculate,
+    buildRoadmap,
+    compareItems,
+    numericPrice,
+    sumPrices,
+  };
+})();

--- a/public/js/stack.js
+++ b/public/js/stack.js
@@ -1,0 +1,251 @@
+/* My Stack: versioned local storage and site-wide controls. */
+(() => {
+  const STORAGE_KEY = 'canivibecodeit:my-stack';
+  const VERSION = 1;
+  const STATUSES = new Set(['targeted', 'building', 'replaced', 'keeping']);
+  const civci = () => window.CanIVibecodeIt || {};
+
+  const validSlugs = (() => {
+    try {
+      return new Set(JSON.parse(document.querySelector('#stack-valid-slugs')?.textContent || '[]'));
+    } catch {
+      return new Set();
+    }
+  })();
+
+  let available = true;
+  let issue = null;
+
+  const emptyState = () => ({ version: VERSION, items: [] });
+
+  const sanitise = (value) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { state: emptyState(), issue: 'malformed' };
+    }
+    if (value.version !== VERSION) {
+      return { state: emptyState(), issue: 'unknown-version' };
+    }
+    if (!Array.isArray(value.items)) {
+      return { state: emptyState(), issue: 'malformed' };
+    }
+
+    const seen = new Set();
+    const items = [];
+    let discarded = 0;
+
+    for (const item of value.items) {
+      const valid =
+        item &&
+        typeof item === 'object' &&
+        typeof item.slug === 'string' &&
+        validSlugs.has(item.slug) &&
+        STATUSES.has(item.status) &&
+        !seen.has(item.slug);
+
+      if (!valid) {
+        discarded += 1;
+        continue;
+      }
+
+      seen.add(item.slug);
+      const clean = { slug: item.slug, status: item.status };
+      if (typeof item.addedAt === 'string') clean.addedAt = item.addedAt;
+      if (typeof item.statusUpdatedAt === 'string') clean.statusUpdatedAt = item.statusUpdatedAt;
+      items.push(clean);
+    }
+
+    return {
+      state: { version: VERSION, items },
+      issue: discarded ? 'discarded-items' : null,
+    };
+  };
+
+  const read = () => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return emptyState();
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        issue = 'malformed';
+        return emptyState();
+      }
+      const result = sanitise(parsed);
+      issue = result.issue;
+      if (result.issue === 'discarded-items') {
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(result.state));
+        } catch {
+          available = false;
+        }
+      }
+      return result.state;
+    } catch {
+      available = false;
+      issue = 'unavailable';
+      return emptyState();
+    }
+  };
+
+  let state = read();
+
+  const snapshot = () => ({
+    version: VERSION,
+    items: state.items.map((item) => ({ ...item })),
+  });
+
+  const announceStorageFallback = () => {
+    if (!available) {
+      civci().toast?.('local storage unavailable · changes last for this page only');
+    }
+  };
+
+  const renderControls = (addedSlug = null) => {
+    const selected = new Set(state.items.map((item) => item.slug));
+
+    document.querySelectorAll('[data-stack-toggle]').forEach((button) => {
+      const inStack = selected.has(button.dataset.stackSlug);
+      const name = button.dataset.stackName || 'this app';
+      const label = button.querySelector('[data-stack-toggle-label]');
+      button.classList.toggle('selected', inStack);
+      button.setAttribute('aria-pressed', String(inStack));
+      button.setAttribute(
+        'aria-label',
+        inStack ? `Remove ${name} from My Stack` : `Add ${name} to My Stack`
+      );
+      if (label) label.textContent = inStack ? '✓ IN MY STACK' : '+ ADD TO STACK';
+    });
+
+    document.querySelectorAll('[data-stack-count]').forEach((el) => {
+      el.textContent = String(state.items.length);
+    });
+    document.querySelectorAll('[data-stack-nav]').forEach((link) => {
+      link.setAttribute(
+        'aria-label',
+        `My Stack, ${state.items.length} ${
+          state.items.length === 1 ? 'subscription' : 'subscriptions'
+        }`
+      );
+      if (addedSlug) {
+        link.classList.remove('acknowledge');
+        void link.offsetWidth;
+        link.classList.add('acknowledge');
+        window.setTimeout(() => link.classList.remove('acknowledge'), 900);
+      }
+    });
+  };
+
+  const emit = (action, slug) => {
+    renderControls(action === 'added' ? slug : null);
+    document.dispatchEvent(
+      new CustomEvent('stack:changed', {
+        detail: {
+          state: snapshot(),
+          available,
+          issue,
+          action,
+          slug,
+        },
+      })
+    );
+  };
+
+  const persist = (next, action, slug) => {
+    state = next;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      available = true;
+      issue = null;
+    } catch {
+      available = false;
+      issue = 'unavailable';
+    }
+    emit(action, slug);
+    announceStorageFallback();
+  };
+
+  const add = (slug) => {
+    if (!validSlugs.has(slug) || state.items.some((item) => item.slug === slug)) return false;
+    persist(
+      {
+        version: VERSION,
+        items: [
+          ...state.items,
+          { slug, status: 'targeted', addedAt: new Date().toISOString() },
+        ],
+      },
+      'added',
+      slug
+    );
+    return true;
+  };
+
+  const remove = (slug) => {
+    if (!state.items.some((item) => item.slug === slug)) return false;
+    persist(
+      { version: VERSION, items: state.items.filter((item) => item.slug !== slug) },
+      'removed',
+      slug
+    );
+    return true;
+  };
+
+  const toggle = (slug) =>
+    state.items.some((item) => item.slug === slug) ? remove(slug) : add(slug);
+
+  const setStatus = (slug, status) => {
+    if (!STATUSES.has(status)) return false;
+    let changed = false;
+    const items = state.items.map((item) => {
+      if (item.slug !== slug || item.status === status) return item;
+      changed = true;
+      return { ...item, status, statusUpdatedAt: new Date().toISOString() };
+    });
+    if (!changed) return false;
+    persist({ version: VERSION, items }, 'status', slug);
+    return true;
+  };
+
+  document.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-stack-toggle]');
+    if (!button) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const slug = button.dataset.stackSlug;
+    const name = button.dataset.stackName || 'subscription';
+    const wasSelected = state.items.some((item) => item.slug === slug);
+    if (!toggle(slug)) return;
+    civci().toast?.(
+      wasSelected ? `${name} removed from your stack` : `target acquired · ${name} added`
+    );
+    civci().track?.(wasSelected ? 'stack_remove' : 'stack_add', { app: slug });
+  });
+
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = read();
+    emit('synced', null);
+  });
+
+  window.MyStack = {
+    key: STORAGE_KEY,
+    version: VERSION,
+    statuses: [...STATUSES],
+    getState: snapshot,
+    isAvailable: () => available,
+    getIssue: () => issue,
+    add,
+    remove,
+    toggle,
+    setStatus,
+    refreshControls: renderControls,
+  };
+
+  renderControls();
+  document.dispatchEvent(
+    new CustomEvent('stack:ready', {
+      detail: { state: snapshot(), available, issue },
+    })
+  );
+})();

--- a/src/components/AppRow.astro
+++ b/src/components/AppRow.astro
@@ -1,25 +1,28 @@
 ---
 import { CATEGORIES } from '../lib/apps.js';
 import VerdictBadge from './VerdictBadge.astro';
+import StackControl from './StackControl.astro';
 
 const { app, rank, votes } = Astro.props;
 const cat = CATEGORIES[app.category];
 ---
 
-<a
+<div
   class="row"
-  href={`/${app.slug}`}
   data-name={app.name.toLowerCase()}
   data-category={app.category}
   data-verdict={app.verdict}
 >
-  <span class="c-app">
-    <span class="rank">{String(rank).padStart(2, '0')}</span>
-    <img src={`/icons/${app.slug}.png`} alt="" width="24" height="24" loading="lazy" />
-    <span class="name">{app.name}</span>
-  </span>
-  <span class="c-cat microlabel">{cat.emoji} {cat.label}</span>
-  <span class="c-price">{app.priceMonthly != null ? `$${app.priceMonthly}/mo` : 'varies'}</span>
-  <span class="c-verdict"><VerdictBadge verdict={app.verdict} /></span>
-  <span class="c-votes" data-votes={app.slug}>{votes}</span>
-</a>
+  <a class="row-link" href={`/${app.slug}`} aria-label={`View ${app.name} build plan`}>
+    <span class="c-app">
+      <span class="rank">{String(rank).padStart(2, '0')}</span>
+      <img src={`/icons/${app.slug}.png`} alt="" width="24" height="24" loading="lazy" />
+      <span class="name">{app.name}</span>
+    </span>
+    <span class="c-cat microlabel">{cat.emoji} {cat.label}</span>
+    <span class="c-price">{app.priceMonthly != null ? `$${app.priceMonthly}/mo` : 'varies'}</span>
+    <span class="c-verdict"><VerdictBadge verdict={app.verdict} /></span>
+    <span class="c-votes" data-votes={app.slug}>{votes}</span>
+  </a>
+  <span class="c-stack"><StackControl {app} compact /></span>
+</div>

--- a/src/components/StackControl.astro
+++ b/src/components/StackControl.astro
@@ -1,0 +1,15 @@
+---
+const { app, compact = false, class: className = '' } = Astro.props;
+---
+
+<button
+  type="button"
+  class:list={['stack-toggle', compact && 'compact', className]}
+  data-stack-toggle
+  data-stack-slug={app.slug}
+  data-stack-name={app.name}
+  aria-pressed="false"
+  aria-label={`Add ${app.name} to My Stack`}
+>
+  <span data-stack-toggle-label>+ ADD TO STACK</span>
+</button>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import '@fontsource-variable/space-grotesk';
 import '@fontsource-variable/jetbrains-mono';
 import '../styles/global.css';
+import { allApps } from '../lib/apps.js';
 
 const {
   title,
@@ -24,6 +25,7 @@ const orgLd = {
 };
 
 const blocks = [orgLd, ...jsonld];
+const appSlugs = allApps().map((app) => app.slug);
 ---
 
 <!doctype html>
@@ -76,6 +78,12 @@ const blocks = [orgLd, ...jsonld];
         <nav class="site-nav">
           <a href="/#death-list">the death list</a>
           <a href="/stats">stats</a>
+          <a
+            class="stack-nav"
+            href="/stack"
+            data-stack-nav
+            aria-label="My Stack, 0 subscriptions"
+          >MY STACK // <span data-stack-count>0</span></a>
           <a href="https://github.com/canivibecodeit/canivibecodeit/blob/main/CONTRIBUTING.md">submit an app</a>
           <a href="mailto:hello@canivibecodeit.com?subject=Sponsoring%20canivibecodeit.com">sponsor</a>
           <button
@@ -110,6 +118,8 @@ const blocks = [orgLd, ...jsonld];
     </footer>
 
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
+    <script id="stack-valid-slugs" type="application/json" set:html={JSON.stringify(appSlugs)}></script>
     <script src={`/js/app.js?v=${__BUILD_ID__}`} defer></script>
+    <script src={`/js/stack.js?v=${__BUILD_ID__}`} defer></script>
   </body>
 </html>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import VerdictBadge from '../components/VerdictBadge.astro';
+import StackControl from '../components/StackControl.astro';
 import Waitlist from '../components/Waitlist.astro';
 import { getApp, relatedApps, yearlySaving, CATEGORIES, VERDICTS } from '../lib/apps.js';
 import { voteCount, voteCounts } from '../lib/db.js';
@@ -100,7 +101,10 @@ const tweet = encodeURIComponent(
         <img src={`/icons/${app.slug}.png`} alt="" width="48" height="48" />
         <h1>Can I vibecode {app.name.split(' / ')[0]}?</h1>
       </span>
-      <VerdictBadge verdict={app.verdict} big />
+      <span class="app-head-actions">
+        <StackControl {app} />
+        <VerdictBadge verdict={app.verdict} big />
+      </span>
     </div>
 
     <div class="stats">
@@ -134,7 +138,7 @@ const tweet = encodeURIComponent(
       )
     }
 
-    <section class="prompt-box" style={!app.prompt ? 'display:none' : undefined}>
+    <section id="build-plan" class="prompt-box" style={!app.prompt ? 'display:none' : undefined}>
       <div class="prompt-head">
         <span class="microlabel">the prompt</span>
         <div class="copy-group" data-slug={app.slug}>
@@ -218,17 +222,20 @@ const tweet = encodeURIComponent(
           <span class="microlabel">also one-shottable</span>
           <div class="related-grid">
             {related.map((r) => (
-              <a class="mini-card" href={`/${r.slug}`}>
-                <img src={`/icons/${r.slug}.png`} alt="" width="26" height="26" loading="lazy" />
-                <span>
-                  <span class="m-name">{r.name}</span>
-                  <br />
-                  <span class="m-meta">
-                    {r.priceMonthly != null ? `$${r.priceMonthly}/mo` : 'varies'} · {CATEGORIES[r.category].label.toLowerCase()}
+              <article class="mini-card app-mini-card">
+                <a class="mini-card-link" href={`/${r.slug}`} aria-label={`View ${r.name} build plan`}>
+                  <img src={`/icons/${r.slug}.png`} alt="" width="26" height="26" loading="lazy" />
+                  <span>
+                    <span class="m-name">{r.name}</span>
+                    <br />
+                    <span class="m-meta">
+                      {r.priceMonthly != null ? `$${r.priceMonthly}/mo` : 'varies'} · {CATEGORIES[r.category].label.toLowerCase()}
+                    </span>
                   </span>
-                </span>
-                <VerdictBadge verdict={r.verdict} />
-              </a>
+                  <VerdictBadge verdict={r.verdict} />
+                </a>
+                <StackControl app={r} compact />
+              </article>
             ))}
           </div>
         </section>

--- a/src/pages/category/[cat].astro
+++ b/src/pages/category/[cat].astro
@@ -70,6 +70,7 @@ const jsonld = [
       <span class="c-price">price</span>
       <span class="c-verdict">verdict</span>
       <span class="c-votes">replaced it</span>
+      <span class="c-stack">my stack</span>
     </div>
     <div id="rows">
       {apps.map((app, i) => <AppRow {app} rank={i + 1} votes={votes(app.slug)} />)}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -110,6 +110,7 @@ const jsonld = [
       <span class="c-price">price</span>
       <span class="c-verdict">verdict</span>
       <span class="c-votes">replaced it</span>
+      <span class="c-stack">my stack</span>
     </div>
     <div id="rows">
       {apps.map((app, i) => <AppRow {app} rank={i + 1} votes={votes(app.slug)} />)}

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -1,0 +1,65 @@
+---
+import Base from '../layouts/Base.astro';
+import { allApps, CATEGORIES, VERDICTS } from '../lib/apps.js';
+
+const apps = allApps().map((app) => ({
+  slug: app.slug,
+  name: app.name,
+  category: app.category,
+  categoryLabel: CATEGORIES[app.category]?.label || app.category,
+  categoryEmoji: CATEGORIES[app.category]?.emoji || '',
+  priceMonthly: app.priceMonthly,
+  verdict: app.verdict,
+  verdictLabel: VERDICTS[app.verdict]?.label || app.verdict,
+  verdictSummary: app.verdictSummary || '',
+  diyTimeEstimate: app.diyTimeEstimate || 'unknown',
+  whatYouLose: Array.isArray(app.whatYouLose) ? app.whatYouLose : [],
+  moatType: app.moatType || '',
+  prompt: app.prompt || '',
+}));
+
+const title = 'My Stack · Personal SaaS replacement planner';
+const description =
+  'Build a personal SaaS replacement roadmap, track subscriptions from targeted to eliminated, and see your realised savings grow.';
+---
+
+<Base {title} {description}>
+  <main class="wrap stack-page">
+    <nav class="crumbs" aria-label="Breadcrumb">
+      <a href="/">the death list</a> / <span class="here">my stack</span>
+    </nav>
+
+    <header class="stack-page-head">
+      <span class="microlabel">LOCAL MISSION FILE · NO ACCOUNT REQUIRED</span>
+      <h1 data-stack-page-title>YOUR STACK // 0 TARGETS</h1>
+      <p>
+        Turn the subscriptions you already pay for into a phased replacement plan. Your mission
+        file stays in this browser.
+      </p>
+    </header>
+
+    <p class="stack-storage-note" data-stack-storage-note hidden></p>
+    <div class="sr-only" data-stack-live role="status" aria-live="polite"></div>
+
+    <div id="stack-mission-control">
+      <section class="stack-loading" aria-live="polite">
+        <span class="terminal-prompt">&gt;</span> READING LOCAL MISSION FILE...
+      </section>
+      <noscript>
+        <section class="stack-empty">
+          <span class="microlabel">JAVASCRIPT REQUIRED FOR LOCAL STORAGE</span>
+          <h2>MISSION FILE OFFLINE</h2>
+          <p>
+            My Stack lives only in your browser, so JavaScript is needed to read it. The death
+            list and every build plan remain available.
+          </p>
+          <a class="btn primary" href="/#death-list">BROWSE THE DEATH LIST</a>
+        </section>
+      </noscript>
+    </div>
+
+    <script id="stack-app-data" type="application/json" set:html={JSON.stringify(apps)}></script>
+    <script src="/js/stack-planner.js" defer></script>
+    <script src="/js/stack-page.js" defer></script>
+  </main>
+</Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -97,6 +97,11 @@ button {
   cursor: pointer;
 }
 
+:where(a, button, select, input, summary):focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+
 img {
   max-width: 100%;
   display: block;
@@ -128,6 +133,18 @@ h3 {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ---------- header ---------- */
@@ -208,6 +225,32 @@ h3 {
 
 .site-nav .gh:active {
   transform: scale(0.96);
+}
+
+.site-nav .stack-nav {
+  color: var(--primary);
+  border: 1px solid var(--primary-dim);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.site-nav .stack-nav:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+.site-nav .stack-nav.acknowledge {
+  animation: stack-acknowledge 0.8s var(--ease-out);
+}
+
+@keyframes stack-acknowledge {
+  45% {
+    background: var(--primary);
+    color: var(--on-primary);
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--primary) 14%, transparent);
+  }
 }
 
 .theme-toggle {
@@ -736,11 +779,18 @@ h3 {
   transition: background-color 0.15s ease;
 }
 
-a.row:hover {
+.row:hover {
   background: var(--surface);
 }
 
-a.row::after {
+.row-link {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.row-link::after {
   content: '→';
   position: absolute;
   right: -6px;
@@ -750,7 +800,7 @@ a.row::after {
   transition: opacity 0.15s ease, transform 0.2s var(--ease-out);
 }
 
-a.row:hover::after {
+.row:hover .row-link::after {
   opacity: 1;
   transform: translateX(0);
 }
@@ -779,7 +829,7 @@ a.row:hover::after {
   transition: transform 0.2s var(--ease-snap);
 }
 
-a.row:hover .c-app img {
+.row:hover .c-app img {
   transform: scale(1.15) rotate(-3deg);
 }
 
@@ -813,6 +863,52 @@ a.row:hover .c-app img {
   font-variant-numeric: tabular-nums;
 }
 
+.c-stack {
+  width: 146px;
+  flex-shrink: 0;
+  padding-left: 12px;
+}
+
+.stack-toggle {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 9px 13px;
+  color: var(--muted);
+  background: var(--surface);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease,
+    transform 0.12s var(--ease-snap);
+}
+
+.stack-toggle.compact {
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 10px;
+  font-size: 10px;
+}
+
+.stack-toggle:hover {
+  color: var(--fg);
+  border-color: var(--primary);
+}
+
+.stack-toggle:active {
+  transform: scale(0.96);
+}
+
+.stack-toggle.selected {
+  color: var(--primary);
+  border-color: var(--primary-dim);
+  background: color-mix(in srgb, var(--primary) 8%, var(--surface));
+}
+
 .badge {
   display: inline-block;
   font-size: 11px;
@@ -823,7 +919,7 @@ a.row:hover .c-app img {
   transition: transform 0.12s var(--ease-snap);
 }
 
-a.row:hover .badge {
+.row:hover .badge {
   transform: scale(1.06);
 }
 
@@ -883,6 +979,13 @@ a.row:hover .badge {
 
 .app-head h1 {
   font-size: clamp(30px, 5vw, 50px);
+}
+
+.app-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .verdict-big {
@@ -1110,6 +1213,22 @@ a.row:hover .badge {
   margin-left: auto;
   font-size: 10px;
   padding: 3px 8px;
+}
+
+.app-mini-card {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.mini-card-link {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.app-mini-card .stack-toggle {
+  margin-top: 11px;
 }
 
 /* actions */
@@ -1609,11 +1728,527 @@ a.row:hover .badge {
   transform: none;
 }
 
+/* ---------- My Stack mission control ---------- */
+
+.stack-page {
+  min-height: 68vh;
+}
+
+.stack-page-head {
+  padding: 34px 0 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.stack-page-head h1 {
+  max-width: 850px;
+  padding-top: 10px;
+  font-size: clamp(36px, 6vw, 68px);
+}
+
+.stack-page-head > p {
+  max-width: 72ch;
+  padding: 14px 0 24px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.stack-storage-note,
+.variable-note {
+  margin-top: 18px;
+  border: 1px solid var(--kinda-bg);
+  border-radius: 7px;
+  padding: 11px 14px;
+  color: var(--kinda-bg);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.stack-loading,
+.stack-empty {
+  margin-top: 34px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 48px 34px;
+}
+
+.stack-loading {
+  color: var(--primary);
+  font-size: 13px;
+}
+
+.stack-empty {
+  text-align: center;
+}
+
+.stack-empty h2 {
+  padding-top: 10px;
+  font-size: clamp(28px, 4vw, 42px);
+}
+
+.stack-empty p {
+  max-width: 64ch;
+  margin: 12px auto 24px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.terminal-prompt {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.stack-summary,
+.escape-plan {
+  padding-top: 46px;
+}
+
+.section-command {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 18px;
+}
+
+.section-command h2 {
+  font-size: clamp(22px, 3vw, 30px);
+}
+
+.stack-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+
+.stack-metric {
+  min-width: 0;
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 19px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.stack-metric strong {
+  display: block;
+  overflow-wrap: anywhere;
+  color: var(--fg);
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3vw, 34px);
+  line-height: 1;
+}
+
+.stack-metric p {
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.stack-metric.positive strong {
+  color: var(--primary);
+}
+
+.stack-metric.conditional strong {
+  color: var(--kinda-bg);
+}
+
+.stack-progress-panel {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  margin-top: 16px;
+  background: var(--border);
+  border: 1px solid var(--border);
+}
+
+.stack-progress-panel > div {
+  min-width: 0;
+  padding: 18px;
+  background: var(--bg);
+}
+
+.stack-progress-panel strong {
+  display: block;
+  padding-top: 7px;
+  color: var(--fg);
+  font-size: 14px;
+}
+
+.stack-progress-panel p {
+  padding-top: 6px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.variable-note {
+  border-color: var(--border);
+  color: var(--muted);
+}
+
+.escape-plan-head {
+  border-top: 2px solid var(--primary);
+  padding: 24px 0;
+}
+
+.escape-plan-head h2 {
+  padding-top: 8px;
+  font-size: clamp(30px, 5vw, 52px);
+}
+
+.escape-plan-head p {
+  max-width: 75ch;
+  padding-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.roadmap-command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 4px 0 20px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 15px 17px;
+  background: var(--surface-2);
+}
+
+.roadmap-command-bar p {
+  padding-top: 3px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.recommendation {
+  border: 1px solid var(--primary);
+  border-radius: 10px;
+  padding: clamp(20px, 4vw, 30px);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--primary) 9%, transparent), transparent 55%),
+    var(--surface);
+  box-shadow: inset 4px 0 0 var(--primary);
+}
+
+.recommendation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(260px, 1.1fr);
+  gap: 28px;
+  padding-top: 16px;
+}
+
+.recommendation-title {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  min-width: 0;
+}
+
+.recommendation-title img {
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  border-radius: 12px;
+}
+
+.recommendation-title h2 {
+  overflow-wrap: anywhere;
+  font-size: clamp(27px, 4vw, 40px);
+}
+
+.recommendation-title p,
+.recommendation-copy p,
+.empty-recommendation > p {
+  padding-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.65;
+}
+
+.recommendation-copy p + p {
+  padding-top: 10px;
+}
+
+.recommendation-copy b,
+.stack-item-brief b {
+  color: var(--fg);
+  font-weight: 700;
+}
+
+.empty-recommendation h2 {
+  padding-top: 9px;
+  font-size: clamp(25px, 4vw, 38px);
+}
+
+.stack-prompt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 18px;
+}
+
+.stack-action {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 11px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 10.5px;
+  font-weight: 700;
+  transition: border-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+}
+
+.stack-action:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.stack-action:active {
+  transform: scale(0.96);
+}
+
+.stack-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.stack-no-prompt {
+  padding-top: 15px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.roadmap-phase {
+  padding-top: 38px;
+}
+
+.roadmap-phase-head {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 14px;
+  align-items: start;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.phase-index {
+  width: 40px;
+  min-height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.roadmap-phase-head h2 {
+  padding-top: 1px;
+  font-size: clamp(21px, 3vw, 29px);
+}
+
+.roadmap-phase-head p {
+  max-width: 78ch;
+  padding-top: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.active-phase .phase-index {
+  border-color: var(--kinda-bg);
+  color: var(--kinda-bg);
+}
+
+.mission-complete .phase-index {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: var(--on-primary);
+}
+
+.keep-phase .phase-index {
+  border-color: var(--no-bg);
+  color: var(--no-bg);
+}
+
+.stack-item-list {
+  display: grid;
+  gap: 12px;
+  padding-top: 14px;
+}
+
+.stack-item {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 17px;
+  background: var(--surface);
+}
+
+.stack-item-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.stack-item-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.stack-item-title img {
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border-radius: 8px;
+}
+
+.stack-item-title h3 {
+  overflow-wrap: anywhere;
+  font-size: 20px;
+}
+
+.stack-item-title h3 a:hover {
+  color: var(--primary);
+}
+
+.stack-item-title p {
+  padding-top: 4px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.stack-item-badges {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.status-badge,
+.roadmap-reason {
+  display: inline-flex;
+  align-items: center;
+  min-height: 25px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 4px 8px;
+  color: var(--muted);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.status-building {
+  border-color: var(--kinda-bg);
+  color: var(--kinda-bg);
+}
+
+.status-replaced {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.status-keeping {
+  border-color: var(--no-bg);
+  color: var(--no-bg);
+}
+
+.stack-item-brief {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  padding-top: 13px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.roadmap-reason {
+  border-color: var(--primary-dim);
+  color: var(--primary);
+}
+
+.stack-item-brief > p {
+  width: 100%;
+  line-height: 1.6;
+}
+
+.stack-status-control {
+  display: grid;
+  grid-template-columns: auto minmax(150px, 210px) auto;
+  align-items: center;
+  justify-content: end;
+  gap: 9px;
+  padding-top: 16px;
+}
+
+.stack-status-control select {
+  min-height: 40px;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 34px 8px 10px;
+  background: var(--bg);
+  color: var(--fg);
+  font: 700 10.5px var(--font-mono);
+}
+
+.stack-remove {
+  min-height: 40px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 11px;
+  color: var(--muted);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.stack-remove:hover {
+  border-color: var(--no-bg);
+  color: var(--no-bg);
+}
+
 /* ---------- responsive ---------- */
 
+@media (max-width: 980px) {
+  .stack-metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .recommendation-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 760px) {
-  .site-nav a:not(.gh) {
+  .site-nav a:not(.stack-nav),
+  .site-nav .gh {
     display: none;
+  }
+
+  .site-header .inner {
+    padding: 11px 14px;
+  }
+
+  .site-nav {
+    gap: 9px;
   }
 
   .hero {
@@ -1627,6 +2262,11 @@ a.row:hover .badge {
   /* Two-line grid card: name row with the verdict pinned right, meta row
      beneath. Grid tracks can't collide the way wrapped flex items could. */
   .row {
+    display: block;
+    padding: 0;
+  }
+
+  .row-link {
     display: grid;
     grid-template-columns: max-content minmax(0, 1fr) max-content;
     align-items: center;
@@ -1684,8 +2324,22 @@ a.row:hover .badge {
     display: none;
   }
 
-  a.row::after {
+  .row-link::after {
     display: none;
+  }
+
+  .c-stack {
+    display: block;
+    width: auto;
+    padding: 0 10px 12px 47px;
+  }
+
+  .app-head-actions {
+    width: 100%;
+  }
+
+  .app-head-actions .stack-toggle {
+    flex: 1;
   }
 
   /* iOS zooms into any focused input with font-size below 16px */
@@ -1705,6 +2359,81 @@ a.row:hover .badge {
 
   .actions .tweet {
     display: none;
+  }
+
+  .stack-page-head {
+    padding-top: 26px;
+  }
+
+  .stack-metrics-grid,
+  .stack-progress-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .stack-metric {
+    min-height: 128px;
+  }
+
+  .roadmap-command-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .roadmap-command-bar .stack-prompt-actions,
+  .recommendation .stack-prompt-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stack-action {
+    width: 100%;
+  }
+
+  .stack-item-main {
+    flex-direction: column;
+  }
+
+  .stack-item-badges {
+    justify-content: flex-start;
+  }
+
+  .stack-status-control {
+    grid-template-columns: 1fr auto;
+    justify-content: stretch;
+  }
+
+  .stack-status-control label {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 440px) {
+  .brand .word {
+    display: none;
+  }
+
+  .roadmap-command-bar .stack-prompt-actions,
+  .recommendation .stack-prompt-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .stack-loading,
+  .stack-empty,
+  .recommendation,
+  .stack-item {
+    padding: 18px 14px;
+  }
+
+  .stack-status-control {
+    grid-template-columns: 1fr;
+  }
+
+  .stack-status-control label {
+    grid-column: auto;
+  }
+
+  .stack-remove {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary

- add accessible My Stack controls across app rows, app pages, and related cards
- persist a versioned local-only stack containing only slugs, statuses, and timestamps
- add a responsive /stack mission-control page with spending, savings, progress, and effort summaries
- generate deterministic quick-win, weekend, longer-build, completed, active, and probably-keep phases
- add status tracking, recommendations, prompt copying, bulk roadmap export, and Cursor/Codex/Claude Code launch actions
- preserve Astro SSR, vanilla JavaScript, the existing visual identity, and repository-authoritative app data

## Validation

- npm run build
- storage schema and malformed-data recovery checks
- calculation and deterministic roadmap ordering checks
- homepage, category, app-detail, and stack routes return successfully
- verified stack buttons are not nested inside app links