### PR TITLE
Sync My Stack replacements with public votes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -355,41 +355,119 @@
     btn.title = voted ? 'click to take your vote back' : '';
   };
 
+  const replacementVoteKey = (slug) => `voted:${slug}`;
+  const isReplacementVoted = (slug) => {
+    try {
+      return !!localStorage.getItem(replacementVoteKey(slug));
+    } catch {
+      return false;
+    }
+  };
+  const rememberReplacementVote = (slug, voted) => {
+    try {
+      if (voted) localStorage.setItem(replacementVoteKey(slug), '1');
+      else localStorage.removeItem(replacementVoteKey(slug));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const renderReplacementVote = (slug, voted, count) => {
+    $$(`[data-vote="${slug}"]`).forEach((btn) => voteLabel(btn, voted));
+    if (count !== undefined && count !== null) {
+      $$(`[data-votes="${slug}"]`).forEach((el) => (el.textContent = count));
+    }
+  };
+
+  // Serialise operations per app so a quick replace/unreplace sequence cannot
+  // leave the public count and the device-local status pointing different ways.
+  const replacementVoteOps = new Map();
+  const setReplacementVote = (slug, replaced) => {
+    const previous = replacementVoteOps.get(slug) || Promise.resolve();
+    const operation = previous
+      .catch(() => {})
+      .then(async () => {
+        const voted = isReplacementVoted(slug);
+        if (voted === replaced) {
+          renderReplacementVote(slug, replaced);
+          return { ok: true, changed: false };
+        }
+
+        try {
+          const res = await fetch(`/api/vote/${slug}`, {
+            method: replaced ? 'POST' : 'DELETE',
+          });
+          // A missing local marker can still represent a vote already counted
+          // for this IP. Treat that response as reconciled, as the existing
+          // vote control has always done.
+          if (replaced && res.status === 429) {
+            rememberReplacementVote(slug, true);
+            renderReplacementVote(slug, true);
+            return { ok: true, changed: false, alreadyCounted: true };
+          }
+          if (!res.ok) return { ok: false };
+
+          const { count } = await res.json();
+          rememberReplacementVote(slug, replaced);
+          renderReplacementVote(slug, replaced, count);
+          return { ok: true, changed: true, count };
+        } catch {
+          return { ok: false };
+        }
+      });
+
+    replacementVoteOps.set(slug, operation);
+    operation.finally(() => {
+      if (replacementVoteOps.get(slug) === operation) replacementVoteOps.delete(slug);
+    });
+    return operation;
+  };
+
+  Object.assign(window.CanIVibecodeIt, { isReplacementVoted, setReplacementVote });
+
   $$('[data-vote]').forEach((btn) => {
     const slug = btn.dataset.vote;
-    if (localStorage.getItem(`voted:${slug}`)) voteLabel(btn, true);
+    if (isReplacementVoted(slug)) voteLabel(btn, true);
 
     btn.addEventListener('click', async () => {
-      const voted = !!localStorage.getItem(`voted:${slug}`);
+      const voted = isReplacementVoted(slug);
       btn.classList.remove('voted');
       void btn.offsetWidth; // restart animation
       btn.classList.add('voted');
-      try {
-        const res = await fetch(`/api/vote/${slug}`, { method: voted ? 'DELETE' : 'POST' });
-        if (!voted && res.status === 429) {
-          localStorage.setItem(`voted:${slug}`, '1');
-          voteLabel(btn, true);
-          toast('already counted · one funeral per person');
-          return;
-        }
-        if (!res.ok) throw new Error();
-        const { count } = await res.json();
-        $$(`[data-votes="${slug}"]`).forEach((el) => (el.textContent = count));
-        if (voted) {
-          localStorage.removeItem(`voted:${slug}`);
-          voteLabel(btn, false);
-          toast('vote taken back · resurrection granted');
-          track('unvote', { app: slug });
-        } else {
-          localStorage.setItem(`voted:${slug}`, '1');
-          voteLabel(btn, true);
-          toast('☠ counted. RIP that subscription.');
-          track('vote', { app: slug });
-        }
-      } catch {
+      const result = await setReplacementVote(slug, !voted);
+      if (!result.ok) {
         toast('something broke · try again');
+        return;
+      }
+
+      window.MyStack?.setReplacement(slug, !voted);
+      if (voted) {
+        toast('vote taken back · target returned to your stack');
+        track('unvote', { app: slug });
+      } else if (result.alreadyCounted) {
+        toast('already counted · marked replaced in your stack');
+      } else {
+        toast('☠ counted · subscription eliminated in your stack');
+        track('vote', { app: slug });
       }
     });
+  });
+
+  // Reconcile pre-existing local state when an app detail page is visited.
+  // This backfills at most the app currently on screen, avoiding burst writes.
+  document.addEventListener('stack:ready', async (event) => {
+    const statuses = new Map(
+      (event.detail?.state?.items || []).map((item) => [item.slug, item.status])
+    );
+    for (const btn of $$('[data-vote]')) {
+      const slug = btn.dataset.vote;
+      if (isReplacementVoted(slug)) {
+        window.MyStack?.setReplacement(slug, true);
+      } else if (statuses.get(slug) === 'replaced') {
+        const result = await setReplacementVote(slug, true);
+        if (result.ok) track('vote_reconciled_from_stack', { app: slug });
+      }
+    }
   });
 
   /* ---------- share ---------- */

--- a/public/js/stack-page.js
+++ b/public/js/stack-page.js
@@ -462,12 +462,30 @@
     }, 1800);
   };
 
-  root.addEventListener('change', (event) => {
+  root.addEventListener('change', async (event) => {
     const select = event.target.closest('[data-stack-status]');
     if (!select) return;
     const item = appsBySlug.get(select.dataset.slug);
     const status = select.value;
+    const previousStatus = currentItems.find((entry) => entry.slug === item?.slug)?.status;
     if (!item || !window.MyStack?.setStatus(item.slug, status)) return;
+
+    const voteResult = civci().setReplacementVote
+      ? await civci().setReplacementVote(item.slug, status === 'replaced')
+      : { ok: true };
+    if (!voteResult.ok) {
+      if (previousStatus) window.MyStack.setStatus(item.slug, previousStatus);
+      civci().toast?.(
+        `community count unavailable · ${item.name} restored to ${statusLabel(previousStatus)}`
+      );
+      return;
+    }
+    if (voteResult.changed) {
+      civci().track?.(status === 'replaced' ? 'vote' : 'unvote', {
+        app: item.slug,
+        source: 'stack',
+      });
+    }
 
     let message = `${item.name} marked ${status}`;
     if (status === 'building') message = `MISSION STARTED · ${item.name}`;

--- a/public/js/stack.js
+++ b/public/js/stack.js
@@ -207,6 +207,57 @@
     return true;
   };
 
+  // Keep the personal replacement state in lockstep with the public
+  // "I replaced this" action. A first-time vote acquires the target as already
+  // replaced; taking the vote back returns only replaced items to TARGETED.
+  const setReplacement = (slug, replaced) => {
+    if (!validSlugs.has(slug)) return false;
+    const existing = state.items.find((item) => item.slug === slug);
+    const now = new Date().toISOString();
+
+    if (replaced) {
+      if (existing?.status === 'replaced') return false;
+      if (!existing) {
+        persist(
+          {
+            version: VERSION,
+            items: [
+              ...state.items,
+              { slug, status: 'replaced', addedAt: now, statusUpdatedAt: now },
+            ],
+          },
+          'added',
+          slug
+        );
+        return true;
+      }
+      persist(
+        {
+          version: VERSION,
+          items: state.items.map((item) =>
+            item.slug === slug ? { ...item, status: 'replaced', statusUpdatedAt: now } : item
+          ),
+        },
+        'status',
+        slug
+      );
+      return true;
+    }
+
+    if (existing?.status !== 'replaced') return false;
+    persist(
+      {
+        version: VERSION,
+        items: state.items.map((item) =>
+          item.slug === slug ? { ...item, status: 'targeted', statusUpdatedAt: now } : item
+        ),
+      },
+      'status',
+      slug
+    );
+    return true;
+  };
+
   document.addEventListener('click', (event) => {
     const button = event.target.closest('[data-stack-toggle]');
     if (!button) return;
@@ -239,6 +290,7 @@
     remove,
     toggle,
     setStatus,
+    setReplacement,
     refreshControls: renderControls,
   };
 


### PR DESCRIPTION
## Summary

- marking an item REPLACED in My Stack now contributes the user's one public replacement vote
- changing a replaced item back to another status removes that public vote; a failed public update restores the previous local status instead of leaving two truths
- clicking the existing I replaced this control now adds the app to My Stack or marks its existing item REPLACED; taking the vote back returns that item to TARGETED
- reconciliation is idempotent and serialised per app, so repeated or rapid actions cannot double-count
- pre-existing vote and stack state reconcile when the relevant app detail page is visited

## Validation

- based directly on post-merge main at 9a7ef09
- npm run build
- JavaScript syntax checks
- local stack replacement transition tests
- public vote add/remove idempotency tests
- diff limited to public/js/app.js, public/js/stack.js, and public/js/stack-page.js