### PR TITLE
Add YouTubeToTranscript (audio-video)

### DIFF
--- a/data/apps/youtubetotranscript.json
+++ b/data/apps/youtubetotranscript.json
@@ -1,0 +1,28 @@
+{
+  "slug": "youtubetotranscript",
+  "name": "YouTubeToTranscript",
+  "domain": "youtubetotranscript.com",
+  "category": "audio-video",
+  "subcategory": "free YouTube transcript reader and translator",
+  "tagline": "Pull any YouTube video's transcript for free, translate to 125+ languages, copy and edit.",
+  "priceMonthly": null,
+  "pricing": { "plan": "Free", "basis": "free web tool and Chrome extension", "source": "https://youtubetotranscript.com", "checkedOn": "2026-07-31", "confidence": "high", "notes": "Free to use; there is a paid API for bulk use.", "native": "free" },
+  "verdict": "kinda",
+  "verdictConfidence": "medium",
+  "verdictSummary": "The core is a one-sitting build: fetch a video's caption track with the open library and render it as readable text. Two honest caveats. First, the product is free, so the question is less about saving money and more about whether you want your own offline copy. Second, a personal build hits the same wall as every YouTube scraper, rate-limits and IP-blocks, whereas the hosted tool stays up because it runs on real transcript infrastructure. What you would rebuild yourself is the reader; what you would not easily rebuild is the browser extension, the 125-language translation, and staying unblocked.",
+  "coreLoopDIY": "Fetch a video's caption track with the open transcript library and show it as clean, copyable text.",
+  "diyTimeEstimate": "one sitting",
+  "requirements": ["Python or Node", "a rotating proxy pool if you use it at any volume"],
+  "whatYouLose": ["the one-click browser extension that works on the YouTube page itself", "translation into 125+ languages", "staying unblocked when YouTube rate-limits your IP", "handling of videos with only auto-generated or missing captions"],
+  "moatType": "convenience surface plus anti-blocking transcript infrastructure",
+  "whyPeopleStillPay": "Nobody pays; it is free. The reason to use it over a script is that it just works from inside YouTube, translates anywhere, and does not fall over when YouTube throttles you, because the hard reliability part is handled upstream.",
+  "priorArt": [
+    { "name": "youtube-transcript-api", "url": "https://github.com/jdepoix/youtube-transcript-api", "desc": "open-source Python library for the core caption fetch" }
+  ],
+  "relatedSlugs": ["transcriptapi"],
+  "pagePriority": 3,
+  "verifiedOneShot": false,
+  "notes": "Free tool; a personal reader is a one-sitting build but breaks on YouTube blocking, which the hosted version does not.",
+  "prompt": "Build a single-page YouTube transcript reader. Stack: one Python file with FastAPI serving a minimal HTML page plus the youtube-transcript-api library, uvicorn, no database. The page has one input for a YouTube URL or id and a Get Transcript button. On submit, call GET /transcript?video= which extracts the id, fetches the caption track, and returns the full text plus timestamped segments as JSON; the page renders clean copyable text with a copy button. Handle disabled or missing captions with a friendly message, never a 500. Support an optional lang= and report which track was used. Include a README and a .env.example. Deliberately out of scope: translation into many languages, a browser extension, accounts, and any proxy pool you do not own, and note in the README that transcript fetches can be rate-limited by YouTube.",
+  "promptCurated": true
+}


### PR DESCRIPTION
Adds **YouTubeToTranscript** (`youtubetotranscript.com` family) under `audio-video`, verdict **kinda**.

Followed CONTRIBUTING: one app, one JSON file; real `category` key; runnable, opinionated, scope-explicit prompt; no em dashes in UI copy; pricing carries `source` + `checkedOn`; `priorArt` credited honestly where it exists.

**Disclosure:** I work on this product. The verdict is written to your honesty bar, not as a pitch. If `kinda` reads wrong or a `whatYouLose` bullet is off, tell me and I'll tighten it. Favicon can be added on request.
