### PR TITLE
Fix stale mobile search navigation and polish mobile UX

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -32,6 +32,24 @@
     track('theme_toggle', { theme: next });
   });
 
+  /* ---------- mobile back to top ---------- */
+  const backToTop = $('[data-back-to-top]');
+  if (backToTop) {
+    const mobile = matchMedia('(max-width: 760px)');
+    const updateBackToTop = () => {
+      const visible = mobile.matches && scrollY > 480;
+      backToTop.classList.toggle('visible', visible);
+      backToTop.disabled = !visible;
+    };
+    addEventListener('scroll', updateBackToTop, { passive: true });
+    mobile.addEventListener('change', updateBackToTop);
+    updateBackToTop();
+    backToTop.addEventListener('click', () => {
+      const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+      scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+    });
+  }
+
   /* ---------- search filter + chips ---------- */
   const search = $('#search');
   const rows = $$('#rows .row, #rows-rest .row');
@@ -78,18 +96,25 @@
   const BADGE = { yes: 'YES', kinda: 'KINDA', no: 'NOT REALLY' };
   let srActive = -1;
 
+  const closeDropdown = () => {
+    if (!srBox) return;
+    srActive = -1;
+    srBox.replaceChildren();
+    srBox.classList.remove('open');
+    search?.setAttribute('aria-expanded', 'false');
+    search?.removeAttribute('aria-activedescendant');
+  };
+
   const renderDropdown = (q) => {
     if (!srBox) return;
     srActive = -1;
     if (!q) {
-      srBox.classList.remove('open');
-      search?.setAttribute('aria-expanded', 'false');
+      closeDropdown();
       return;
     }
     const hits = rowData.filter((r) => r.lower.includes(q));
     if (!hits.length) {
-      srBox.classList.remove('open');
-      search?.setAttribute('aria-expanded', 'false');
+      closeDropdown();
       return;
     }
     const top = hits.slice(0, 6);
@@ -115,7 +140,17 @@
   const setActive = (i) => {
     const items = srRows();
     srActive = ((i % items.length) + items.length) % items.length;
-    items.forEach((el, j) => el.classList.toggle('active', j === srActive));
+    items.forEach((el, j) => {
+      const active = j === srActive;
+      el.classList.toggle('active', active);
+      el.setAttribute('aria-selected', String(active));
+      if (active) {
+        el.id = 'search-result-active';
+        search?.setAttribute('aria-activedescendant', el.id);
+      } else {
+        el.removeAttribute('id');
+      }
+    });
   };
 
   search?.addEventListener('input', () => {
@@ -131,14 +166,21 @@
       e.preventDefault();
       setActive(srActive - 1);
     } else if (e.key === 'Escape') {
-      renderDropdown('');
+      closeDropdown();
     } else if (e.key === 'Enter') {
-      const target = items[srActive >= 0 ? srActive : 0];
-      if (target) location.href = target.getAttribute('href');
+      // Never follow stale results from an earlier, broader query. Mobile
+      // keyboards send Enter even when the now-empty dropdown is invisible.
+      const target = srBox?.classList.contains('open')
+        ? items[srActive >= 0 ? srActive : 0]
+        : null;
+      if (target) {
+        e.preventDefault();
+        location.href = target.getAttribute('href');
+      }
     }
   });
   document.addEventListener('click', (e) => {
-    if (srBox && !e.target.closest('.search-wrap')) renderDropdown('');
+    if (srBox && !e.target.closest('.search-wrap')) closeDropdown();
   });
 
   // Chips are real links (SEO); on the homepage they filter in place instead.

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -32,17 +32,15 @@
     track('theme_toggle', { theme: next });
   });
 
-  /* ---------- mobile back to top ---------- */
+  /* ---------- back to top ---------- */
   const backToTop = $('[data-back-to-top]');
   if (backToTop) {
-    const mobile = matchMedia('(max-width: 760px)');
     const updateBackToTop = () => {
-      const visible = mobile.matches && scrollY > 480;
+      const visible = scrollY > 480;
       backToTop.classList.toggle('visible', visible);
       backToTop.disabled = !visible;
     };
     addEventListener('scroll', updateBackToTop, { passive: true });
-    mobile.addEventListener('change', updateBackToTop);
     updateBackToTop();
     backToTop.addEventListener('click', () => {
       const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;

--- a/src/components/AppRow.astro
+++ b/src/components/AppRow.astro
@@ -21,5 +21,9 @@ const cat = CATEGORIES[app.category];
   <span class="c-cat microlabel">{cat.emoji} {cat.label}</span>
   <span class="c-price">{app.priceMonthly != null ? `$${app.priceMonthly}/mo` : 'varies'}</span>
   <span class="c-verdict"><VerdictBadge verdict={app.verdict} /></span>
-  <span class="c-votes" data-votes={app.slug}>{votes}</span>
+  <span class="c-votes">
+    <span class="mobile-vote-mark" aria-hidden="true">☠</span>
+    <span data-votes={app.slug}>{votes}</span>
+    <span class="sr-only">people replaced it</span>
+  </span>
 </a>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -109,6 +109,9 @@ const blocks = [orgLd, ...jsonld];
       </div>
     </footer>
 
+    <button class="back-to-top" type="button" data-back-to-top aria-label="Back to top" disabled>
+      <span aria-hidden="true">↑</span>
+    </button>
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
     <script src={`/js/app.js?v=${__BUILD_ID__}`} defer></script>
   </body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,6 +130,18 @@ h3 {
   color: var(--muted);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---------- header ---------- */
 
 .site-header {
@@ -813,6 +825,10 @@ a.row:hover .c-app img {
   font-variant-numeric: tabular-nums;
 }
 
+.mobile-vote-mark {
+  display: none;
+}
+
 .badge {
   display: inline-block;
   font-size: 11px;
@@ -1473,6 +1489,7 @@ a.row:hover .badge {
 /* ---------- waitlist ---------- */
 
 .waitlist {
+  width: calc(100% - 40px);
   margin-top: 72px;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -1596,6 +1613,10 @@ a.row:hover .badge {
   opacity: 1;
 }
 
+.back-to-top {
+  display: none;
+}
+
 /* ---------- reveal on scroll ---------- */
 
 .reveal {
@@ -1612,6 +1633,53 @@ a.row:hover .badge {
 /* ---------- responsive ---------- */
 
 @media (max-width: 760px) {
+  .back-to-top {
+    position: fixed;
+    right: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    z-index: 45;
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border: 1px solid var(--primary-dim);
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--surface) 92%, transparent);
+    color: var(--primary);
+    box-shadow: var(--shadow);
+    font-size: 20px;
+    line-height: 1;
+    opacity: 0;
+    translate: 0 10px;
+    pointer-events: none;
+    backdrop-filter: blur(8px);
+    transition: opacity 0.18s ease, translate 0.22s var(--ease-out),
+      transform 0.12s var(--ease-snap);
+  }
+
+  .back-to-top.visible {
+    opacity: 1;
+    translate: 0;
+    pointer-events: auto;
+  }
+
+  .back-to-top:active {
+    transform: scale(0.92);
+  }
+
+  .site-header .inner {
+    gap: 8px;
+    padding: 12px 14px;
+  }
+
+  .site-nav {
+    gap: 10px;
+  }
+
+  .site-nav .gh {
+    padding-inline: 9px;
+  }
+
   .site-nav a:not(.gh) {
     display: none;
   }
@@ -1628,7 +1696,7 @@ a.row:hover .badge {
      beneath. Grid tracks can't collide the way wrapped flex items could. */
   .row {
     display: grid;
-    grid-template-columns: max-content minmax(0, 1fr) max-content;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     align-items: center;
     column-gap: 8px;
     row-gap: 5px;
@@ -1667,21 +1735,39 @@ a.row:hover .badge {
     grid-column: 1;
     grid-row: 2;
     width: auto;
+    min-width: 0;
     font-size: 10.5px;
     padding-left: 37px;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .c-price {
-    grid-column: 2 / 4;
+    grid-column: 2;
     grid-row: 2;
     width: auto;
     font-size: 11px;
     color: var(--muted);
+    white-space: nowrap;
   }
 
   .c-votes {
-    display: none;
+    display: inline-flex;
+    grid-column: 3;
+    grid-row: 2;
+    align-items: center;
+    justify-self: end;
+    gap: 4px;
+    margin-left: 0;
+    color: var(--muted);
+    font-size: 10.5px;
+    white-space: nowrap;
+  }
+
+  .mobile-vote-mark {
+    display: inline;
+    color: var(--primary);
   }
 
   a.row::after {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1614,7 +1614,41 @@ a.row:hover .badge {
 }
 
 .back-to-top {
-  display: none;
+  position: fixed;
+  right: 24px;
+  bottom: calc(24px + env(safe-area-inset-bottom));
+  z-index: 45;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid var(--primary-dim);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  color: var(--primary);
+  box-shadow: var(--shadow);
+  font-size: 20px;
+  line-height: 1;
+  opacity: 0;
+  translate: 0 10px;
+  pointer-events: none;
+  backdrop-filter: blur(8px);
+  transition: opacity 0.18s ease, translate 0.22s var(--ease-out),
+    transform 0.12s var(--ease-snap), border-color 0.15s ease;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  translate: 0;
+  pointer-events: auto;
+}
+
+.back-to-top:hover {
+  border-color: var(--primary);
+}
+
+.back-to-top:active {
+  transform: scale(0.92);
 }
 
 /* ---------- reveal on scroll ---------- */
@@ -1634,37 +1668,10 @@ a.row:hover .badge {
 
 @media (max-width: 760px) {
   .back-to-top {
-    position: fixed;
     right: 16px;
     bottom: calc(16px + env(safe-area-inset-bottom));
-    z-index: 45;
-    display: grid;
     width: 42px;
     height: 42px;
-    place-items: center;
-    border: 1px solid var(--primary-dim);
-    border-radius: 50%;
-    background: color-mix(in srgb, var(--surface) 92%, transparent);
-    color: var(--primary);
-    box-shadow: var(--shadow);
-    font-size: 20px;
-    line-height: 1;
-    opacity: 0;
-    translate: 0 10px;
-    pointer-events: none;
-    backdrop-filter: blur(8px);
-    transition: opacity 0.18s ease, translate 0.22s var(--ease-out),
-      transform 0.12s var(--ease-snap);
-  }
-
-  .back-to-top.visible {
-    opacity: 1;
-    translate: 0;
-    pointer-events: auto;
-  }
-
-  .back-to-top:active {
-    transform: scale(0.92);
   }
 
   .site-header .inner {


### PR DESCRIPTION
## What changed

- fully clear stale search suggestions when the current query has no matches
- only let Enter navigate while a valid search dropdown is open
- keep combobox active-result and expanded state in sync
- show replacement totals on mobile as a compact `☠ count`, without adding another crowded column
- keep long row metadata contained so it cannot create horizontal scrolling
- give the newsletter card proper mobile gutters and tighten the narrow header layout
- add a mobile-only back-to-top button that appears after scrolling

## Why

On mobile, a broader query could leave hidden suggestion markup behind. Typing a later non-match such as `Slack` and pressing Enter could therefore open an unrelated stale result such as Sleek.

## Verification

- reproduced the stale-result path and confirmed Enter remains on the homepage after a no-match query
- confirmed `Slack` now visibly resolves to the current `Slack Pro` listing
- measured 390px, 360px, and 320px viewports: document width matches viewport and app rows report zero overflow
- checked the back-to-top button hidden, visible-after-scroll, and returned-to-top states
- `node --check public/js/app.js`
- `npm run build`

Closes #58
