### PR TITLE
UI suggestion: Type random app logos in the hero

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -78,6 +78,47 @@
   const BADGE = { yes: 'YES', kinda: 'KINDA', no: 'NOT REALLY' };
   let srActive = -1;
 
+  /* ---------- randomized hero logo typewriter ---------- */
+  const heroLogo = $('[data-hero-logo]');
+  if (heroLogo && rowData.length) {
+    const logoImg = $('img', heroLogo);
+    const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let previousLogo = -1;
+
+    const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const randomLogo = () => {
+      let next = Math.floor(Math.random() * rowData.length);
+      if (rowData.length > 1 && next === previousLogo) next = (next + 1) % rowData.length;
+      previousLogo = next;
+      return rowData[next];
+    };
+    const setLogo = async (item) => {
+      logoImg.src = item.icon;
+      heroLogo.title = item.name;
+      try {
+        await logoImg.decode();
+      } catch {
+        // The next cycle will try another local icon if this one cannot decode.
+      }
+    };
+
+    if (reduceMotion) {
+      void setLogo(randomLogo()).then(() => heroLogo.classList.add('typed'));
+    } else {
+      void (async () => {
+        while (heroLogo.isConnected) {
+          heroLogo.classList.remove('typed');
+          await setLogo(randomLogo());
+          await wait(420);
+          heroLogo.classList.add('typed');
+          await wait(1400);
+          heroLogo.classList.remove('typed');
+          await wait(500);
+        }
+      })();
+    }
+  }
+
   const renderDropdown = (q) => {
     if (!srBox) return;
     srActive = -1;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,16 @@ const jsonld = [
 
 <Base {title} {description} {jsonld}>
   <section class="hero">
-    <h1>Can I vibecode <span class="blank">___</span>?</h1>
+    <h1>
+      <span aria-hidden="true">
+        Can I vibecode
+        <span class="hero-logo-type" data-hero-logo>
+          <img alt="" />
+          <span class="hero-logo-cursor"></span>
+        </span>?
+      </span>
+      <span class="sr-only">Can I vibecode it?</span>
+    </h1>
     <p class="sub">Some subscriptions are businesses. Some are just a prompt.</p>
     <div class="search-wrap">
       <div class="search">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,6 +130,18 @@ h3 {
   color: var(--muted);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---------- header ---------- */
 
 .site-header {
@@ -254,8 +266,43 @@ h3 {
   font-size: clamp(40px, 7vw, 84px);
 }
 
-.hero h1 .blank {
-  color: var(--primary);
+.hero-logo-type {
+  position: relative;
+  display: inline-block;
+  width: 1.02em;
+  height: 0.9em;
+  margin-left: 0.12em;
+  margin-right: 0.02em;
+  vertical-align: -0.1em;
+}
+
+.hero-logo-type img {
+  position: absolute;
+  top: 0.02em;
+  left: 0.02em;
+  width: 0.84em;
+  height: 0.84em;
+  border-radius: 0.16em;
+  object-fit: cover;
+  opacity: 0;
+}
+
+.hero-logo-cursor {
+  position: absolute;
+  top: 0.05em;
+  left: 0;
+  width: 0.07em;
+  height: 0.78em;
+  background: var(--primary);
+  animation: blink 0.75s steps(1) infinite;
+}
+
+.hero-logo-type.typed img {
+  opacity: 1;
+}
+
+.hero-logo-type.typed .hero-logo-cursor {
+  left: 0.9em;
 }
 
 .hero .sub {


### PR DESCRIPTION
## UI suggestion

Replace the static `___` in “Can I vibecode ___?” with app logos treated as single typewriter characters:

1. the cursor blinks immediately after `vibecode `
2. one complete, randomly selected app logo appears and the cursor jumps to its right
3. the logo is deleted and the cursor returns to its original position
4. the cycle repeats with a different app

The logo appears atomically rather than being revealed with a sweep, and the fixed-width slot prevents the headline from shifting during each cycle. Hovering the logo exposes the app name.

## Accessibility

- assistive technology receives the stable heading “Can I vibecode it?”
- the animated presentation is hidden from screen readers
- `prefers-reduced-motion` shows one static random logo instead of cycling

## Verification

- tested the absent → typed → deleted cursor positions at a mobile viewport
- confirmed the headline width remains unchanged throughout the cycle
- confirmed the document remains viewport-width with no horizontal overflow
- `node --check public/js/app.js`
- `npx astro build`
