### PR TITLE
Curate the PostHog prompt, fix the truncated tagline

### DIFF
--- a/data/apps/posthog.json
+++ b/data/apps/posthog.json
@@ -5,7 +5,7 @@
   "appURL": "https://posthog.com",
   "category": "analytics",
   "subcategory": "web and product analytics",
-  "tagline": "Collect a bounded event stream and answer a few product questions without recreating the full platfo",
+  "tagline": "Product analytics with session replay, feature flags, and a data warehouse",
   "priceMonthly": null,
   "pricing": {
     "plan": "Usage based",
@@ -13,34 +13,32 @@
     "source": "https://posthog.com/pricing",
     "checkedOn": "2026-07-31",
     "confidence": "high",
-    "notes": "No stable monthly subscription; pricing is usage based with a free allowance.",
+    "notes": "No stable monthly subscription; pricing is usage based with a free allowance. Page checked 2026-07-31: product analytics free to 1M events/month, then from $0.00005/event.",
     "native": "usage-based",
     "kind": "usage-based",
     "currency": "USD"
   },
   "verdict": "no",
   "verdictConfidence": "high",
-  "verdictSummary": "A consolation build is possible, but the paid product's decisive value sits outside a solo rebuild. For PostHog, collect a bounded event stream and answer a few product questions without recreating the full platform. The hard boundary is broad product stack, warehouse, feature flags, replay, global ingestion, and engineering depth, plus data pipeline reliability and analytical depth.",
-  "coreLoopDIY": "Collect a bounded stream of privacy-conscious first-party events, answer a small set of product questions, and retain raw data under the owner's control without recreating the full platform.",
+  "verdictSummary": "First-party collection and a dashboard that answers your top five questions is one sitting of work, and PostHog's free tier covers a million events a month before you pay anything. What the bill buys past that is the rest of the platform: session replay, feature flags, SQL over years of events, and ingestion that stays correct while your event schema drifts underneath it.",
+  "coreLoopDIY": "Collect first-party pageviews and custom events from your own sites, keep the raw rows yourself, and answer a handful of product questions from a local dashboard.",
   "diyTimeEstimate": "closest consolation build: one sitting",
   "requirements": [
-    "Docker",
-    "ClickHouse",
-    "PostgreSQL",
-    "public HTTPS collector endpoint",
-    "site script access"
+    "Node 22",
+    "a small always-on VPS",
+    "a domain you control, for first-party collection"
   ],
   "whatYouLose": [
-    "broad product stack, warehouse, feature flags, replay, global ingestion, and engineering depth",
-    "identity stitching",
     "session replay",
-    "warehouse connectors",
-    "high-volume global ingestion and support"
+    "feature flags and experiments",
+    "identity stitching across devices",
+    "SQL over years of events",
+    "ingestion that stays up without you watching it"
   ],
   "moatType": "data pipeline reliability and analytical depth",
   "replacementScope": "single-product first-party analytics",
   "ongoingBurden": "event schemas, bot filtering, identity, late data, retention, query cost, privacy, backups, and always-on ingestion",
-  "whyPeopleStillPay": "People still pay for PostHog because teams pay because analytics must keep collecting and remain trustworthy while the product changes underneath it. The recurring cost buys event schemas, bot filtering, identity, late data, retention, query cost, privacy, backups, and always-on ingestion, not just the visible interface.",
+  "whyPeopleStillPay": "Teams pay because analytics has to keep collecting and stay trustworthy while the product changes underneath it. The bill buys bot filtering, identity resolution, late-arriving data, retention, query cost, and someone else getting paged when ingestion stops. The charts are the cheap part.",
   "priorArt": [
     {
       "name": "Umami",
@@ -55,7 +53,7 @@
   ],
   "pagePriority": 5,
   "verifiedOneShot": false,
-  "notes": "Editorial comparison targets the Usage based plan and a single-product first-party analytics DIY substitute. Recheck price before merge.",
-  "prompt": "Build a closest honest personal substitute for PostHog in an empty repository.\nUse Next.js 15, TypeScript, ClickHouse, PostgreSQL, and Docker Compose; do not offer alternative stacks.\nThe core loop is: collect a bounded stream of privacy-conscious first-party events, answer a small set of product questions, and retain raw data under the owner's control without recreating the full platform.\nMake the first run work locally with one documented command.\nStore all user data locally by default and make export straightforward.\nPut secrets in .env, ship .env.example, and never commit credentials.\nShip a lightweight browser SDK for page views and explicit custom events.\nCreate projects, API keys, environments, event names, and a documented event schema.\nIngest idempotently, filter obvious bots, truncate IP data, and avoid fingerprinting.\nBuild dashboards for visitors, sessions, funnels, retention, sources, pages, and events.\nExpose filters by date, environment, device, country, referrer, and selected properties.\nAdd retention controls, raw-event export, deletion, health checks, and backup instructions.\nInclude clear empty, loading, success, and recoverable error states.\nAdd input validation, safe filenames, and graceful handling of unavailable APIs.\nWrite focused tests for the core transformation and one end-to-end happy path.\nCreate a README with setup, architecture, permissions, data location, and backup steps.\nDo not add accounts, billing, telemetry, analytics, or a hosted control plane.\nDo not claim to reproduce proprietary data, network liquidity, regulated access, or frontier infrastructure.\nDeliberately leave out cross-site identity graphs.\nDeliberately leave out session replay and automatic DOM capture.\nDeliberately leave out warehouse-scale reverse ETL and enterprise governance.\nFinish by running the tests and listing the exact commands used.",
-  "promptCurated": false
+  "notes": "The charts are the easy part. A pipeline that never quietly stops collecting is the product, and that is the part you inherit when you self-host.",
+  "prompt": "Build me a self-hosted web analytics box to replace PostHog. Requirements:\n\n- One Node 22 + Express process with better-sqlite3, serving the collector and the\n  dashboard on port 8787. No frontend framework, no build step, no Docker.\n- A tracker.js I paste on my sites: pageviews on load and history change, plus\n  window.track('signup', { plan: 'pro' }), POSTed to /e on my own domain so\n  collection stays first-party.\n- One SQLite events table: site, event, path, referrer, UTM fields, country from the\n  proxy header, device class, and a JSON properties blob.\n- Count visitors by a daily-rotating salted hash of IP plus user agent, salt in .env.\n  No cookie, never the raw IP. That is the whole privacy design, keep it.\n- Dashboard at / with a date range picker: visitors and pageviews by day, top pages,\n  referrers, countries, any event split by one property, and a three-step funnel.\n- Nightly rollup into a daily-summary table, raw events pruned past the retention\n  window in .env, /export.csv for the raw rows.\n- Basic auth on the dashboard, collector open. No accounts, no telemetry, my box\n  holds the only copy.\n- Out of scope: session replay, feature flags, and stitching one person across\n  devices. Do not build a plugin system or a warehouse connector.\n- README: the snippet to paste, where the SQLite file lives, and how to back it up.",
+  "promptCurated": true
 }


### PR DESCRIPTION
PostHog was one of the `"promptCurated": false` entries, and the tagline was truncated mid-word. One app, one PR.

**Prompt rewritten** to `scripts/prompt-style-guide.md`: opens `Build me a ... to replace PostHog. Requirements:`, 9 flat bullets, 20 lines, one stack (Node 22 · Express · better-sqlite3), storage named, interface stated (dashboard on :8787), salt and password in `.env`, the privacy line once, out-of-scope pulled from `whatYouLose`, README bullet at the end. No template phrases, no em dashes. `promptCurated` flipped to `true`.

Scoped to the consolation build the 🔴 verdict implies: a first-party collector plus a dashboard, explicitly not replay, flags, or a warehouse. The verdict itself is unchanged.

**Other fields brought up to standard:**

- `tagline` was cut off at "recreating the full platfo" and described the DIY build, not PostHog. Now describes the product, matching granola/figma.
- `verdictSummary` and `whyPeopleStillPay` had generator artifacts ("For PostHog, ...", "teams pay because"). Rewritten as one honest paragraph each.
- `requirements` listed Docker, ClickHouse, and PostgreSQL, which the rewritten prompt does not use. Now Node 22, a small VPS, a domain you control.
- `whatYouLose` first bullet was a six-item run-on. Split into clean bullets, which the prompt's out-of-scope line then draws from.
- `notes` lost the internal "Recheck price before merge" and says something editorial instead.

**Pricing rechecked** against posthog.com/pricing on 2026-07-31: product analytics free to 1M events/month, then from $0.00005/event. `priceMonthly: null` and the usage-based block stay as they were; the specifics went into `pricing.notes`.

Icon already exists at `public/icons/posthog.png`, so no asset change.

Happy to cut this back to the prompt alone if you would rather keep copy edits separate.
