### PR TITLE
fix: navigation to all categories not working

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -154,7 +154,7 @@
   if (chips && rows.length) {
     chips.addEventListener('click', (e) => {
       const chip = e.target.closest('.chip');
-      if (!chip || e.metaKey || e.ctrlKey) return;
+      if (!chip || !chip.hasAttribute('data-cat') || e.metaKey || e.ctrlKey) return;
       e.preventDefault();
       activeCat = chip.dataset.cat || '';
       $$('.chip', chips).forEach((c) => c.classList.toggle('active', c === chip));

--- a/src/pages/category/[cat].astro
+++ b/src/pages/category/[cat].astro
@@ -57,7 +57,7 @@ const jsonld = [
     </div>
 
     <nav class="chips" style="justify-content: flex-start; padding-top: 18px;" aria-label="Categories">
-      <a class="chip" href="/">⚡ all</a>
+      <a class="chip" href="/categories">⚡ all</a>
       {
         cats.map((c) => (
           <a class={`chip${c.slug === cat ? ' active' : ''}`} href={`/category/${c.slug}`}>


### PR DESCRIPTION
## What this does
Fixes a bug on the homepage where clicking the "all categories →" link did nothing instead of navigating to the `/categories` page. 

## Why it was happening
The `app.js` script attaches a click listener to the `#chips` container to enable in-place filtering for category chips. It was intercepting all clicks on elements with the `.chip` class and calling `e.preventDefault()`. Since the "all categories" link also has the `.chip` class for styling, its default navigation was being blocked. 

## The fix
Updated the click handler in `app.js` to check for the presence of the `data-cat` attribute.