### PR TITLE
feat: add categories to category breadcrumbs

### DIFF
--- a/src/pages/category/[cat].astro
+++ b/src/pages/category/[cat].astro
@@ -28,7 +28,8 @@ const jsonld = [
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'The Death List', item: 'https://canivibecodeit.com/' },
-      { '@type': 'ListItem', position: 2, name: meta.label, item: `https://canivibecodeit.com/category/${cat}` },
+      { '@type': 'ListItem', position: 2, name: 'Categories', item: 'https://canivibecodeit.com/categories' },
+      { '@type': 'ListItem', position: 3, name: meta.label, item: `https://canivibecodeit.com/category/${cat}` },
     ],
   },
   {


### PR DESCRIPTION
## What this does
Adds a link to the `/categories` page in the breadcrumbs on individual category pages.