### PR TITLE
Cache OG renders by content hash, skip unchanged apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/generated/
 node_modules/
 dist/
 .astro/
+.og-cache.json
 
 # editor / OS junk
 .DS_Store

--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -3,12 +3,42 @@
 import satori from 'satori';
 import { Resvg } from '@resvg/resvg-js';
 import sharp from 'sharp';
-import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 const outDir = path.join(root, 'public/og');
 mkdirSync(outDir, { recursive: true });
+
+// Local build cache: maps output file -> hash of everything that fed its render.
+// Not committed (gitignored) — a fresh checkout just rebuilds everything once.
+// Delete it to force a full rebuild after editing the templates below.
+const cacheFile = path.join(root, '.og-cache.json');
+const loadCache = () => {
+  try { return JSON.parse(readFileSync(cacheFile, 'utf8')); } catch { return {}; }
+};
+const saveCache = (cache) => writeFileSync(cacheFile, JSON.stringify(cache));
+
+// Changing the template, background, or fonts invalidates every cached hash at
+// once — the only case where a stale image would otherwise slip through.
+const templateHash = createHash('sha256')
+  .update(readFileSync(new URL(import.meta.url)))
+  .update(readFileSync(path.join(root, 'scripts/og-background.png')))
+  .digest('hex');
+
+const hashFor = (key) => createHash('sha256').update(templateHash).update(key).digest('hex');
+
+// Cheap stand-in for the icon's bytes: size+mtime changes whenever the file does,
+// without re-reading and base64-encoding it just to check the cache.
+const iconStatKey = (slug) => {
+  try {
+    const s = statSync(path.join(root, 'public/icons', `${slug}.png`));
+    return `${s.size}:${s.mtimeMs}`;
+  } catch {
+    return 'noicon';
+  }
+};
 
 const fonts = [
   { name: 'Space Grotesk', weight: 700, data: readFileSync(path.join(root, 'scripts/fonts/SpaceGrotesk-Bold.ttf')) },
@@ -149,6 +179,16 @@ async function render(node, file) {
   console.log('og:', file);
 }
 
+async function renderCached(node, file, hashKey, cache) {
+  const hash = hashFor(hashKey);
+  if (cache[file] === hash && existsSync(path.join(outDir, file))) {
+    console.log('og (cached):', file);
+    return;
+  }
+  await render(node, file);
+  cache[file] = hash;
+}
+
 const apps = readdirSync(path.join(root, 'data/apps'))
   .filter((f) => f.endsWith('.json'))
   .map((f) => JSON.parse(readFileSync(path.join(root, 'data/apps', f), 'utf8')));
@@ -186,10 +226,16 @@ function siteCard() {
 const range = process.env.OG_RANGE;
 if (range) {
   const [start, end] = range.split(':').map(Number);
-  for (const app of apps.slice(start, end)) await render(appCard(app), `${app.slug}.png`);
+  const cache = loadCache();
+  for (const app of apps.slice(start, end)) {
+    await renderCached(appCard(app), `${app.slug}.png`, JSON.stringify(app) + '|' + iconStatKey(app.slug), cache);
+  }
+  saveCache(cache);
 } else {
-  await render(homeCard(mrr), 'home.png');
-  await render(siteCard(), 'vibecode-this-site.png');
+  const cache = loadCache();
+  await renderCached(homeCard(mrr), 'home.png', `home:${mrr}`, cache);
+  await renderCached(siteCard(), 'vibecode-this-site.png', 'site', cache);
+  saveCache(cache);
   const { spawnSync } = await import('node:child_process');
   const self = new URL(import.meta.url).pathname;
   const CHUNK = 100;


### PR DESCRIPTION
Stacked on #94 — this diff will look larger than it should (includes #94's image regen) until that one merges; it'll shrink to just the 2 files below automatically once main catches up. The actual change here is small.

## Summary
- `generate-og.mjs` re-rendered all 954+ cards through satori/resvg/sharp on every build regardless of what actually changed — ~3.5 minutes even when editing a single app entry.
- Add a local, gitignored cache (`.og-cache.json`) keyed by a hash of each app's JSON + icon file stat + the render template itself (own source + background PNG), so unchanged apps skip straight to the existing file.
- Warm rebuilds: **3m33s → ~1.5s**. Editing one app re-renders only that app plus `home.png` (its MRR total shifts with any price change).
- Cache is not committed — a fresh clone or CI checkout just does one full render, same behavior as today.

## Test plan
- [x] Cold run (no cache) renders all 954+2, builds cache
- [x] Warm run with no changes: 954/954 cache hits, ~1.5s
- [x] Editing one app's `priceMonthly`: only that app + `home.png` re-render, rest stay cached
- [x] Reverting the edit re-renders both again, output is byte-identical to the original committed PNGs
- [x] `npm run build` end-to-end passes