### PR TITLE
Fix verdict badge contrast failures in dark mode NOT REALLY and light mode YES

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,13 @@
   --kinda-fg: #1a1200;
   --no-bg: #ff4444;
   --no-fg: #ffffff;
+  /* Small bold badge text (11px/700) doesn't qualify for WCAG's large-text
+     3:1 exception, so it needs the normal 4.5:1 minimum. --no-bg itself stays
+     brighter for its other job (readable as red text on this dark background,
+     line ~1040/2550) — this is a separate, darker red just for white-on-red
+     badge fills, which --no-bg (3.41:1) fails. */
+  --no-badge-bg: #ed0000;
+  --yes-badge-bg: var(--primary);
   /* The ticker counts money people kept, not money destroyed — so it's green.
      Red stays reserved for NOT REALLY verdicts. */
   --ticker: #33e667;
@@ -52,6 +59,11 @@
   --kinda-fg: #241800;
   --no-bg: #e03131;
   --no-fg: #ffffff;
+  /* --no-bg already clears 4.5:1 against white at badge size here, so it
+     doubles as the badge fill. --primary (white-on-green) doesn't (3.58:1) —
+     --yes-badge-bg is a badge-only darker green that does. */
+  --no-badge-bg: var(--no-bg);
+  --yes-badge-bg: #0c883e;
   --ticker: #0e9c47;
   --ticker-dim: #628a70;
   --ticker-label: #2f8a52;
@@ -706,8 +718,8 @@ h3 {
 }
 
 .vchip.yes.active {
-  background: var(--primary);
-  border-color: var(--primary);
+  background: var(--yes-badge-bg);
+  border-color: var(--yes-badge-bg);
   color: var(--on-primary);
 }
 
@@ -718,8 +730,8 @@ h3 {
 }
 
 .vchip.no.active {
-  background: var(--no-bg);
-  border-color: var(--no-bg);
+  background: var(--no-badge-bg);
+  border-color: var(--no-badge-bg);
   color: var(--no-fg);
 }
 
@@ -836,7 +848,7 @@ a.row:hover .badge {
 }
 
 .badge.yes {
-  background: var(--primary);
+  background: var(--yes-badge-bg);
   color: var(--on-primary);
 }
 
@@ -846,7 +858,7 @@ a.row:hover .badge {
 }
 
 .badge.no {
-  background: var(--no-bg);
+  background: var(--no-badge-bg);
   color: var(--no-fg);
 }
 


### PR DESCRIPTION
## Summary

`.badge` and `.vchip.active` (verdict pills, used on every app row and every detail page) render text at 11px/700 weight — below WCAG's large-text threshold (needs 18px regular or 14px bold to qualify for the relaxed 3:1 ratio), so they're held to the normal-text 4.5:1 AA minimum. Measured actual contrast of every verdict/theme combo:

| Combo | Ratio | Result |
|---|---|---|
| Dark, KINDA | 10.14:1 | pass |
| Dark, YES | 11.15:1 | pass |
| Dark, **NOT REALLY** | **3.41:1** | **fail** |
| Light, KINDA | 9.40:1 | pass |
| Light, **YES** | **3.58:1** | **fail** |
| Light, NOT REALLY | 4.51:1 | pass |

## Fix

Rather than changing `--no-bg` or `--primary` directly (each used ~5-40 other places, including as plain text color against the *opposite* background — darkening/lightening either trades one contrast failure for another elsewhere, confirmed by checking each existing usage), this adds two tokens scoped to just the badge fill:

- `--no-badge-bg`: defaults to `var(--no-bg)` in light mode (already passes at 4.51:1), overridden to `#ed0000` in dark mode (4.56:1) where the shared `--no-bg` (`#ff4444`) doesn't.
- `--yes-badge-bg`: defaults to `var(--primary)` in dark mode (already passes at 11.15:1), overridden to `#0c883e` in light mode (4.56:1) where the shared `--primary` (`#0e9c47`) doesn't.

Both new values are the minimal darkening (via HSL lightness, hue/saturation preserved) needed to clear 4.5:1 with white text — visually still clearly "red" / "green", not a hue shift.

`.badge.yes`, `.badge.no`, `.vchip.yes.active`, `.vchip.no.active` now use the scoped tokens. `.verdict-chip i` (an 8x8px decorative status dot, not text) is unaffected — it's held to the non-text 3:1 threshold, which it already clears.

## Test plan
- [x] Computed all 6 verdict/theme combinations against WCAG AA (4.5:1) before and after
- [x] Verified darkening `--no-bg`/`--primary` directly would have regressed their other usages (e.g. `--no-bg` as plain error text on the dark background drops from 5.72:1 to 4.27:1 if changed globally) — confirms the scoped-token approach over a blanket token change
- [x] Screenshot comparison, dark mode home page — badges read clearly, no visual regression
- [x] `npm run build` passes