### PR TITLE
Link each entry to the product it judges

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -16,6 +16,10 @@ const cat = CATEGORIES[app.category];
 const v = VERDICTS[app.verdict];
 const saving = yearlySaving(app);
 
+// 781 of the 953 entries carry appURL and every entry carries domain, so the
+// official site is always one honest link away. Prefer the explicit URL.
+const appLink = app.appURL || `https://${app.domain}`;
+
 const moats = (app.moatTags ?? [])
   .filter((t) => MOAT_TAGS[t])
   .map((t) => ({ tag: t, label: MOAT_TAGS[t], emoji: MOAT_TAG_EMOJI[t] }));
@@ -114,6 +118,7 @@ const tweet = encodeURIComponent(
       {app.diyTimeEstimate && <span>build time <b>{app.diyTimeEstimate}</b></span>}
       <span>category <b>{cat.emoji} {cat.label.toLowerCase()}</b></span>
       <span>replaced by <b data-votes={app.slug}>{votes}</b> people</span>
+      <span>the paid thing <a class="app-link" href={appLink} target="_blank" rel="noopener">{app.domain}</a></span>
     </div>
 
     {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -929,6 +929,18 @@ a.row:hover .badge {
   font-weight: 500;
 }
 
+.stats .app-link {
+  color: var(--fg);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+  text-underline-offset: 3px;
+}
+
+.stats .app-link:hover {
+  text-decoration-color: currentColor;
+}
+
 /* prompt block */
 
 .prompt-box {


### PR DESCRIPTION
Every entry page names a paid product and never links to it. `appURL` is already in the data (781 of 953 entries) and `domain` is in all of them, so this is one line of template.

Adds a "the paid thing" cell to the stats row: `appURL`, falling back to `https://<domain>` so no entry is left without one. `target="_blank" rel="noopener"`, styled to match the row.

Happy to add `rel="nofollow"` if you would rather not pass link equity, or to drop the fallback and only link the 781 explicit ones.