### PR TITLE
Check the style guide in CI, as warnings

### DIFF
--- a/data/apps/motion.json
+++ b/data/apps/motion.json
@@ -42,14 +42,7 @@
   ],
   "moatNotes": "algorithm/integrations",
   "whyPeopleStillPay": "They pay because the calendar stays organized without manual drag-and-drop.",
-  "priorArt": [
-    {
-      "name": "No maintained direct clone found",
-      "url": "not found",
-      "desc": "There are scheduling libraries, but no obvious maintained open-source Motion-equivalent co",
-      "status": "not found"
-    }
-  ],
+  "priorArt": [],
   "relatedSlugs": [
     "reclaim-ai",
     "calendly",

--- a/data/apps/surfer-seo.json
+++ b/data/apps/surfer-seo.json
@@ -45,14 +45,7 @@
   ],
   "moatNotes": "data access/workflow/model wrapper",
   "whyPeopleStillPay": "They pay because content optimization needs repeatable data and an editor that writers will use.",
-  "priorArt": [
-    {
-      "name": "OpenSearch + custom scripts",
-      "url": "not found",
-      "desc": "No single maintained open-source Surfer clone found; DIY usually combines SERP APIs, NLP l",
-      "status": "not found"
-    }
-  ],
+  "priorArt": [],
   "relatedSlugs": [
     "frase",
     "quickbooks-online",

--- a/scripts/prompt-style-guide.md
+++ b/scripts/prompt-style-guide.md
@@ -3,8 +3,13 @@
 How to write the `prompt` field in `data/apps/*.json`. A one-shot build prompt is what a
 reader pastes into Claude Code, Codex CLI, or Cursor in an empty folder to get a working
 personal replacement for a paid product in one session. This guide exists to rewrite the
-~94 prompts with `"promptCurated": false`, which were template-generated and read like
-filled-in forms, not like a builder telling an agent what to make.
+template-generated prompts, which read like filled-in forms, not like a builder telling an
+agent what to make.
+
+`npm run validate` prints the current count under `prompt-shape`. It checks the shape
+below rather than the `promptCurated` flag, because the flag is self-reported and wrong in
+both directions: entries carrying hand-written prompts still say `false`, and a few say
+`true` over generator output.
 
 Reference exemplars (match their voice and density):
 - `data/apps/granola.json`

--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -1,14 +1,47 @@
 /* Every app entry is a PR, so the schema check has to be the reviewer that never
    gets tired: shape, vocabularies, and the fields the pages actually read.
    Run with `npm run validate`. No dependencies, on purpose. */
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { CATEGORIES, MOAT_TAGS, VERDICTS } from '../src/lib/apps.js';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 const dir = path.join(root, 'data/apps');
+const iconsDir = path.join(root, 'public/icons');
+
+// Style-guide rules are warnings by default so the existing backlog does not turn
+// CI red. `npm run validate -- --strict` fails on them, for the day it is empty.
+const strict = process.argv.includes('--strict');
+const verbose = process.argv.includes('--verbose');
+const today = new Date().toISOString().slice(0, 10);
 
 const UNITS = ['flat', 'per-seat', 'usage', 'one-time', 'custom'];
+
+// scripts/prompt-style-guide.md, the parts a script can actually check.
+const MARKETING = [
+  'seamless',
+  'powerful',
+  'beautiful',
+  'delightful',
+  'robust',
+  'blazing',
+  'intuitive',
+  'production-ready',
+];
+const COPY_FIELDS = ['tagline', 'verdictSummary', 'coreLoopDIY', 'moatNotes', 'whyPeopleStillPay', 'notes', 'prompt'];
+
+// The guide's required shape: an opening line ending in "Requirements:", then flat
+// "- " bullets. Both exemplars (granola, calendly) pass; every generated prompt in
+// the repo fails, which is the point. promptCurated is self-reported and wrong in
+// both directions, so the shape is the only claim that can be verified.
+const promptShape = (prompt) => {
+  const lines = prompt.split('\n');
+  return {
+    lines: lines.length,
+    bullets: lines.filter((l) => l.startsWith('- ')).length,
+    opener: lines.slice(0, 2).join(' ').includes('Requirements:'),
+  };
+};
 
 const isStr = (v) => typeof v === 'string' && v.trim() !== '';
 const isStrArray = (v) => Array.isArray(v) && v.every((x) => isStr(x));
@@ -43,10 +76,16 @@ const REQUIRED = {
 };
 
 const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+const slugs = new Set(files.map((f) => path.basename(f, '.json')));
 const problems = [];
+const warnings = new Map(); // rule -> [messages]
 
 for (const file of files) {
   const bad = (msg) => problems.push(`${file}: ${msg}`);
+  const warn = (rule, msg) => {
+    if (!warnings.has(rule)) warnings.set(rule, []);
+    warnings.get(rule).push(`${file}: ${msg}`);
+  };
   let app;
   try {
     app = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
@@ -84,18 +123,72 @@ for (const file of files) {
     if (!UNITS.includes(app.pricing.unit)) {
       bad(`pricing.unit "${app.pricing.unit}" is not one of ${UNITS.join(' | ')}`);
     }
+    // "Prices drift, receipts matter" only holds if the receipt has a real date on it.
+    const checked = app.pricing.checkedOn;
+    if (!isStr(checked) || !/^\d{4}-\d{2}-\d{2}$/.test(checked)) {
+      bad(`pricing.checkedOn "${checked}" is not a YYYY-MM-DD date`);
+    } else if (checked > today) {
+      bad(`pricing.checkedOn "${checked}" is in the future`);
+    }
+    if (app.pricing.source != null && !/^https?:\/\//.test(app.pricing.source)) {
+      bad(`pricing.source "${app.pricing.source}" is not a URL`);
+    }
   }
 
   if (Array.isArray(app.priorArt)) {
     app.priorArt.forEach((p, i) => {
       if (!p || typeof p !== 'object' || !isStr(p.name) || !isStr(p.url)) {
         bad(`priorArt[${i}] needs a name and a url`);
+      } else if (!/^https?:\/\//.test(p.url)) {
+        // The page renders these as anchors, so a placeholder ships a dead link.
+        // Use [] when there is no prior art.
+        bad(`priorArt[${i}].url "${p.url}" is not a URL`);
       }
     });
   }
   if (app.relatedSlugs !== undefined && !isStrArray(app.relatedSlugs)) {
     bad('relatedSlugs must be an array of slugs');
+  } else {
+    for (const r of app.relatedSlugs ?? []) {
+      if (!slugs.has(r)) bad(`relatedSlugs: "${r}" is not an entry in data/apps`);
+    }
   }
+
+  // The app page reads /icons/<slug>.png unconditionally; a missing file is a
+  // broken image on a live page, not a cosmetic problem.
+  if (isStr(app.slug) && !existsSync(path.join(iconsDir, `${app.slug}.png`))) {
+    bad(`no icon at public/icons/${app.slug}.png`);
+  }
+
+  // --- style guide, warnings by default ---
+
+  if (isStr(app.prompt)) {
+    // Shape only. The guide's 15-to-30-line rule is deliberately not checked: both
+    // of its own exemplars are 14 lines, so the rule as written would fail them.
+    const { bullets, opener } = promptShape(app.prompt);
+    if (!opener || bullets < 5) {
+      warn(
+        'prompt-shape',
+        `prompt is not in the house shape (${bullets} bullets${opener ? '' : ', no "Requirements:" opener'})`,
+      );
+      if (app.promptCurated === true) {
+        warn('promptCurated-mislabelled', 'promptCurated is true but the prompt is not in the house shape');
+      }
+    }
+    const found = MARKETING.filter((w) => app.prompt.toLowerCase().includes(w));
+    if (found.length) warn('marketing-words', `prompt uses ${found.join(', ')}`);
+  }
+
+  for (const field of COPY_FIELDS) {
+    if (typeof app[field] === 'string' && app[field].includes('—')) {
+      warn('em-dash', `${field} contains an em dash, the house rule is ·`);
+    }
+  }
+}
+
+if (strict) {
+  for (const list of warnings.values()) problems.push(...list);
+  warnings.clear();
 }
 
 if (problems.length) {
@@ -105,3 +198,14 @@ if (problems.length) {
 }
 
 console.log(`✓ ${files.length} app files pass`);
+
+if (warnings.size) {
+  const total = [...warnings.values()].reduce((n, l) => n + l.length, 0);
+  console.log(`\n${total} style-guide warning(s) · scripts/prompt-style-guide.md`);
+  for (const [rule, list] of [...warnings].sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`\n  ${rule} · ${list.length}`);
+    (verbose ? list : list.slice(0, 3)).forEach((m) => console.log(`    ${m}`));
+    if (!verbose && list.length > 3) console.log(`    ...and ${list.length - 3} more (--verbose)`);
+  }
+  console.log('\nWarnings do not fail the build. Run with --strict once a rule is clean.');
+}


### PR DESCRIPTION
The validator checks shape and vocabularies. Everything in `prompt-style-guide.md` and the house rules is currently unenforced, so the backlog is invisible and nothing stops it growing.

**New errors** (all four have zero violations today, so CI stays green):

- `relatedSlugs` must resolve to a real entry
- an icon must exist at `public/icons/<slug>.png`, the page renders it unconditionally
- `priorArt[].url` must be a URL. This found two: `motion` and `surfer-seo` carried a placeholder `"url": "not found"`, which shipped as `<a href="not found">` on both pages. Cleared to `[]` per the documented convention, which is the only data change here.
- `pricing.checkedOn` must be a real date and not in the future, `pricing.source` must be a URL

**New warnings** (printed with counts, do not fail the build):

- `prompt-shape` · 788. Opening line with `Requirements:` plus at least 5 flat `- ` bullets. Both exemplars pass, every generated prompt fails.
- `marketing-words` · 18, `em-dash` · 10, `promptCurated-mislabelled` · 12

`npm run validate -- --strict` promotes warnings to errors for the day a rule is clean, `--verbose` lists every hit instead of the first three.

Two notes. The guide opens by saying there are ~94 uncurated prompts; the real number by shape is 788, so I reworded that line to point at the command instead of a number that goes stale. And I did not check the 15-to-30-line rule: `granola` and `calendly` are both 14 lines, so the rule as written fails its own exemplars.