### PR TITLE
Add PromptDrive (team prompt library, $5/user/mo)

### DIFF
--- a/data/apps/promptdrive.json
+++ b/data/apps/promptdrive.json
@@ -52,25 +52,13 @@
       "lastCommit": "2026-08",
       "selfHost": "docker",
       "checkedOn": "2026-08-10"
-    },
-    {
-      "name": "Skills Board",
-      "url": "https://www.skillsboard.sh",
-      "type": "open-source",
-      "repo": "https://github.com/TommyBez/skillsboard",
-      "platforms": ["web", "self-hosted"],
-      "desc": "A team library for AI agent skills rather than raw prompts: save once with the GitHub source attached, teammates grab the source, an install command, or a ZIP, and agents search it over authenticated MCP.",
-      "stars": 5,
-      "lastCommit": "2026-08",
-      "selfHost": "hosted",
-      "checkedOn": "2026-08-10"
     }
   ],
   "rejectedAlternatives": [],
   "relatedSlugs": ["promptdc"],
   "pagePriority": 2,
   "verifiedOneShot": false,
-  "notes": "Submitted by the team behind Skills Board (listed in the escape hatch, disclosed): verdict, pricing, and prompt written against PromptDrive's public pages.",
+  "notes": "Submitted by the team behind a neighbouring prompt tool: verdict, pricing, and prompt written against PromptDrive's public pages.",
   "prompt": "Build me a local prompt library to replace PromptDrive. Requirements:\n\n- A single-process Node app (Express + better-sqlite3, vanilla HTML/CSS/JS, no build\n  step) serving a web UI on localhost:4321.\n- Prompts have a title, body, notes, a folder, and tags. Store everything in one\n  SQLite file next to the app; create the schema on first run.\n- Full-text search across title, body, and tags with SQLite FTS5, filtering live as\n  I type.\n- Support {{variable}} placeholders in prompt bodies: opening a prompt renders one\n  input per distinct placeholder and shows the filled prompt update live.\n- One-click copy of the filled prompt with navigator.clipboard and a brief copied\n  confirmation.\n- Import and export the whole library as one JSON file from the UI; also export any\n  folder as Markdown, one file per prompt.\n- Keyboard-first: / focuses search, arrow keys move through results, Enter opens,\n  c copies.\n- No accounts, no cloud, no telemetry, no API calls: this is a filing cabinet, not a\n  chat client. Deliberately out: team sharing, comments, the browser extension, and\n  running prompts against models.\n- Include a README with install and run steps, backup advice (copy the .sqlite\n  file), and a seed script that loads five example prompts.",
   "promptCurated": true
 }

--- a/data/apps/promptdrive.json
+++ b/data/apps/promptdrive.json
@@ -1,0 +1,76 @@
+{
+  "slug": "promptdrive",
+  "name": "PromptDrive",
+  "domain": "promptdrive.ai",
+  "category": "ai-writing",
+  "subcategory": "team prompt library & collaboration",
+  "tagline": "Organize, share, and collaborate on AI prompts for ChatGPT, Claude, and Gemini in one team workspace",
+  "priceMonthly": 5,
+  "pricing": {
+    "plan": "Team",
+    "basis": "monthly per user",
+    "unit": "per-seat",
+    "native": "5 USD",
+    "source": "https://promptdrive.ai/#pricing",
+    "checkedOn": "2026-08-10",
+    "confidence": "high",
+    "notes": "Business at $10/user/month adds in-workspace chat with bring-your-own API keys for OpenAI, Claude, and Gemini; Personal is free.",
+    "freeTier": "The free Personal plan includes unlimited prompts, public sharing links, and the Chrome extension."
+  },
+  "verdict": "yes",
+  "verdictConfidence": "high",
+  "verdictSummary": "The core loop, save a prompt, file it in a folder, tag it, find it, fill in variables, copy it into a chat, is a small CRUD app around one SQLite table and ships in one sitting. What the subscription actually sells is the multiplayer part: shared folders with permissions, comments that let a team iterate on a prompt, and a Chrome extension that surfaces the library inside ChatGPT, Claude, and Gemini.",
+  "coreLoopDIY": "Save prompts with folders and tags in SQLite, search them as you type, fill {{variables}} in a generated form, and copy the result into any chat AI.",
+  "diyTimeEstimate": "one sitting",
+  "requirements": [
+    "Node.js 20+",
+    "a browser"
+  ],
+  "whatYouLose": [
+    "team sharing, comments, and permissions",
+    "the Chrome extension inside ChatGPT, Claude, and Gemini",
+    "running prompts against models from the same workspace with your own API keys",
+    "public share links with unique URLs",
+    "someone else's servers & support"
+  ],
+  "moatTags": [
+    "execution-polish",
+    "integrations"
+  ],
+  "moatNotes": "collaboration workflow, extension reach into the chat tools, and a maintained multi-model workspace",
+  "whyPeopleStillPay": "Teams pay for the shared workspace: private folders someone else maintains, comments that turn a prompt into a living document, permissions, and an extension that follows the team into whichever chat AI they use. A local library covers one person fine; the per-seat fee is really about keeping five people on the same page.",
+  "priorArt": [],
+  "alternatives": [
+    {
+      "name": "Langfuse",
+      "url": "https://langfuse.com/",
+      "type": "open-source",
+      "repo": "https://github.com/langfuse/langfuse",
+      "platforms": ["web", "self-hosted"],
+      "desc": "An open source LLM engineering platform whose prompt management gives a team versioned, shared prompts, if you are happy running the whole stack for that one feature.",
+      "stars": 32824,
+      "lastCommit": "2026-08",
+      "selfHost": "docker",
+      "checkedOn": "2026-08-10"
+    },
+    {
+      "name": "Skills Board",
+      "url": "https://www.skillsboard.sh",
+      "type": "open-source",
+      "repo": "https://github.com/TommyBez/skillsboard",
+      "platforms": ["web", "self-hosted"],
+      "desc": "A team library for AI agent skills rather than raw prompts: save once with the GitHub source attached, teammates grab the source, an install command, or a ZIP, and agents search it over authenticated MCP.",
+      "stars": 5,
+      "lastCommit": "2026-08",
+      "selfHost": "hosted",
+      "checkedOn": "2026-08-10"
+    }
+  ],
+  "rejectedAlternatives": [],
+  "relatedSlugs": ["promptdc"],
+  "pagePriority": 2,
+  "verifiedOneShot": false,
+  "notes": "Submitted by the team behind Skills Board (listed in the escape hatch, disclosed): verdict, pricing, and prompt written against PromptDrive's public pages.",
+  "prompt": "Build me a local prompt library to replace PromptDrive. Requirements:\n\n- A single-process Node app (Express + better-sqlite3, vanilla HTML/CSS/JS, no build\n  step) serving a web UI on localhost:4321.\n- Prompts have a title, body, notes, a folder, and tags. Store everything in one\n  SQLite file next to the app; create the schema on first run.\n- Full-text search across title, body, and tags with SQLite FTS5, filtering live as\n  I type.\n- Support {{variable}} placeholders in prompt bodies: opening a prompt renders one\n  input per distinct placeholder and shows the filled prompt update live.\n- One-click copy of the filled prompt with navigator.clipboard and a brief copied\n  confirmation.\n- Import and export the whole library as one JSON file from the UI; also export any\n  folder as Markdown, one file per prompt.\n- Keyboard-first: / focuses search, arrow keys move through results, Enter opens,\n  c copies.\n- No accounts, no cloud, no telemetry, no API calls: this is a filing cabinet, not a\n  chat client. Deliberately out: team sharing, comments, the browser extension, and\n  running prompts against models.\n- Include a README with install and run steps, backup advice (copy the .sqlite\n  file), and a seed script that loads five example prompts.",
+  "promptCurated": true
+}


### PR DESCRIPTION
Adds PromptDrive (promptdrive.ai), a team prompt library: Team $5/user/month, Business $10 adds BYOK chat, free Personal tier. Verdict: yes. The personal loop (save, tag, search, fill {{variables}}, copy) is a one-sitting CRUD app; what the subscription sells is the multiplayer part: shared folders, comments, permissions, and the Chrome extension inside ChatGPT, Claude, and Gemini.

Escape hatch: Langfuse (32.8k stars, versioned team prompts if you run the stack) and Skills Board. Disclosure, also in the entry notes: I am the founder of Skills Board (free hosted, MIT). The verdict and pricing were written against PromptDrive's public pages, checked 2026-08-10, and the bigger third-party project leads the alternatives list.

validate-apps.mjs passes (997 files). One app per PR. No icon included: happy to add public/icons/promptdrive.png if you want it in the PR instead of via scripts/fetch-icons.mjs.