### PR TITLE
Add codespring.json for CodeSpring app details

### DIFF
--- a/data/apps/codespring.json
+++ b/data/apps/codespring.json
@@ -1,0 +1,45 @@
+{
+  "slug": "codespring",
+  "name": "CodeSpring",
+  "domain": "codespring.app",
+  "category": "dev-tools",
+  "subcategory": "AI build planning + PRD/kanban for vibe coders",
+  "tagline": "Visual mind-mapping tool that turns app ideas into PRDs and kanban tasks for AI coding agents",
+  "priceMonthly": 39,
+  "discontinued": null,
+  "pricing": {
+    "plan": "Pro",
+    "basis": "monthly",
+    "unit": "flat",
+    "source": "https://www.codespring.app/#pricing",
+    "checkedOn": "2026-08-10",
+    "confidence": "medium",
+    "notes": "Business plan is £99/mo for 5 seats; credits are consumed per AI generation on top of the base plan.",
+    "native": "39 GBP",
+    "freeTier": null
+  },
+  "verdict": "kinda",
+  "verdictConfidence": "medium",
+  "verdictSummary": "The core loop, a mind map that turns feature notes into PRDs and kanban tasks fed to a coding agent, is just structured prompting and file generation, well within reach of a one-shot build. What's missing is the polish: the visual mind-map canvas, MCP/CLI integrations with Claude Code, Cursor and Codex, and the docs search. A DIY version gets you most of the value but with a rougher UI and manual glue between the planning docs and your agent of choice.",
+  "coreLoopDIY": "A local app where you map features on a canvas, write notes per feature, and generate a PRD + task list file that you feed to your coding agent.",
+  "diyTimeEstimate": "multi-day",
+  "requirements": ["OpenAI/Anthropic API key"],
+  "whatYouLose": ["polished drag-and-drop mind-map canvas", "MCP server integration with Cursor/Claude Code/Codex", "semantic docs search", "hosted kanban sync across devices", "prebuilt skills library"],
+  "moatTags": ["execution-polish", "integrations"],
+  "moatNotes": "MCP/CLI wiring into multiple coding agents plus the mind-map UI are the parts that take real time to replicate; the underlying PRD generation is just an LLM prompt.",
+  "whyPeopleStillPay": "Non-technical builders pay for the guided, visual workflow and the fact it already talks to Cursor, Claude Code and Codex out of the box, rather than assembling their own prompt templates and task tracker.",
+  "priorArt": [
+    { "name": "excalidraw", "url": "https://github.com/excalidraw/excalidraw", "desc": "open-source canvas for mapping ideas visually" },
+    { "name": "BMAD-METHOD", "url": "https://github.com/bmadcode/BMAD-METHOD", "desc": "open-source agentic planning framework that generates PRDs and task breakdowns for coding agents" }
+  ],
+  "alternatives": [
+    { "name": "AFFiNE", "url": "https://affine.pro", "type": "open-source", "repo": "https://github.com/toeverything/AFFiNE", "platforms": ["web", "macos", "windows", "linux", "self-hosted"], "desc": "Whiteboard-plus-docs workspace you can use to map features and write specs by hand.", "stars": 49000, "lastCommit": "2026-07", "selfHost": "docker", "checkedOn": "2026-08-10" }
+  ],
+  "rejectedAlternatives": [],
+  "relatedSlugs": [],
+  "pagePriority": 3,
+  "verifiedOneShot": false,
+  "notes": "Planning-layer tool, not a hosted app itself; value is mostly in agent integrations and UI polish.",
+  "prompt": "Build me a local-first app-planning tool in Next.js.\nStack: Next.js + TypeScript, SQLite via better-sqlite3, Tailwind for UI. No auth, single user, runs on localhost.\nCore loop:\n1. A canvas page where I can add draggable \"feature\" nodes (title + free-text notes), connect them with lines, and save the layout to SQLite.\n2. A \"Generate PRD\" button per feature that calls the Anthropic API (key from .env) with the feature notes and produces a structured PRD (problem, scope, out-of-scope, acceptance criteria) saved as a markdown file in /docs.\n3. A simple kanban board (To Do / In Progress / Done) auto-seeded with tasks parsed from each generated PRD, editable by drag-and-drop.\n4. An \"Export\" button that zips all PRD markdown files plus a tasks.json for dropping into any coding agent's context folder.\nOut of scope: multi-user accounts, real-time collaboration, MCP server, mobile app, billing.\nInclude a README explaining setup, the .env variable needed, and how to point Claude Code/Cursor at the exported /docs folder.",
+  "promptCurated": true
+}

--- a/data/apps/codespring.json
+++ b/data/apps/codespring.json
@@ -5,7 +5,7 @@
   "category": "dev-tools",
   "subcategory": "AI build planning + PRD/kanban for vibe coders",
   "tagline": "Visual mind-mapping tool that turns app ideas into PRDs and kanban tasks for AI coding agents",
-  "priceMonthly": 39,
+  "priceMonthly": 53,
   "discontinued": null,
   "pricing": {
     "plan": "Pro",


### PR DESCRIPTION
Adds CodeSpring (codespring.app) to the death list.

- verdict: kinda — the mind-map-to-PRD/kanban core loop is a one-session AI build, but MCP/CLI integrations with Cursor, Claude Code and Codex plus the polished canvas UI are real gaps.
- pricing: £39/mo Pro, £99/mo Business (5 seats), sourced from codespring.app pricing section, checked 2026-08-10.
- alternatives: AFFiNE as a free/OSS canvas+docs option.
- includes a runnable one-shot DIY prompt (Next.js + SQLite, local-first PRD/kanban generator).

No favicon included yet — happy to add public/icons/codespring.png in a follow-up if needed.