### PR TITLE
Add ideabrowser.json for Ideabrowser

### DIFF
--- a/data/apps/ideabrowser.json
+++ b/data/apps/ideabrowser.json
@@ -1,0 +1,44 @@
+{
+  "slug": "ideabrowser",
+  "name": "Ideabrowser",
+  "domain": "ideabrowser.com",
+  "category": "user-research",
+  "subcategory": "curated startup idea database + trend/market research",
+  "tagline": "Daily curated startup ideas backed by trend data, market sizing and AI research agents",
+  "priceMonthly": 42,
+  "discontinued": null,
+  "pricing": {
+    "plan": "Starter",
+    "basis": "annual, billed yearly",
+    "unit": "flat",
+    "source": "https://www.ideabrowser.com/pricing",
+    "checkedOn": "2026-08-10",
+    "confidence": "high",
+    "notes": "Pro is $1,499/yr (adds AI Research Agent, AI Chat Strategist, data exports); Empire is $2,999/yr (adds coaching/community). Billed annually only.",
+    "native": "499 USD/year",
+    "freeTier": "Free plan gives one fully-researched Idea of the Day with full market analysis, but no access to the searchable database or AI tools."
+  },
+  "verdict": "kinda",
+  "verdictConfidence": "medium",
+  "verdictSummary": "Scraping Reddit/search trends and having an LLM draft a business-opportunity writeup per idea is a weekend build. What's genuinely hard to replicate is the editorial curation, the accumulated database of 1,000+ pre-researched ideas, and the trend-signal pipeline built up over time. A DIY version can generate plausible-sounding ideas on demand but starts from zero data and zero curation.",
+  "coreLoopDIY": "A script that pulls trending Reddit/Google-Trends signals, feeds them to an LLM with a fixed prompt template, and outputs a formatted market-opportunity brief.",
+  "diyTimeEstimate": "one sitting",
+  "requirements": ["OpenAI/Anthropic API key", "Reddit or Google Trends API access"],
+  "whatYouLose": ["1,000+ already-curated and human-vetted ideas", "historical trend database and idea archive", "AI Research Agent for arbitrary custom ideas", "community, coaching and Q&A strategist sessions", "data exports and idea-suggest personalization"],
+  "moatTags": ["proprietary-data", "brand-trust"],
+  "moatNotes": "The value is less the AI writeup and more the accumulated, editorially-curated dataset and Greg Isenberg's audience/brand pulling in submissions and attention.",
+  "whyPeopleStillPay": "Builders pay to skip the research grind: a constantly refreshed, pre-vetted idea backlog plus market sizing is worth more to them than the marginal cost of prompting an LLM themselves, especially since the curation quality is hard to bootstrap solo.",
+  "priorArt": [
+    { "name": "praw", "url": "https://github.com/praw-dev/praw", "desc": "Python Reddit API wrapper for pulling trending threads" }
+  ],
+  "alternatives": [
+    { "name": "IdeaProof", "url": "https://ideaproof.io/startup-ideas-database", "type": "free", "repo": null, "platforms": ["web"], "desc": "Free searchable database of startup ideas with market size and viability scores, no subscription.", "stars": null, "lastCommit": null, "selfHost": "hosted", "checkedOn": "2026-08-10" }
+  ],
+  "rejectedAlternatives": [],
+  "relatedSlugs": [],
+  "pagePriority": 3,
+  "verifiedOneShot": false,
+  "notes": "The AI writeup is easy to clone; the curated idea backlog and trend history are what actually took time to build.",
+  "prompt": "Build me a startup-idea trend scanner as a Next.js app.\nStack: Next.js + TypeScript, SQLite via better-sqlite3, Tailwind. No auth, single user, localhost only.\nCore loop:\n1. A cron-style script (runnable manually via a button) that fetches the top posts from a fixed list of subreddits (via Reddit's public JSON endpoints, no API key needed) mentioning pain points or requests.\n2. Pass each candidate post to the Anthropic API (key from .env) with a fixed prompt asking it to draft a one-page opportunity brief: problem, target user, rough market size guess, an MVP scope, and a one-line pricing idea.\n3. Save each brief to SQLite and show them in a simple feed, newest first, with a save/star toggle.\n4. A search box to filter saved briefs by keyword.\nOut of scope: payments, email delivery, multi-user accounts, historical trend charts, editorial curation.\nInclude a README covering setup, the .env variable, and a note that brief quality depends entirely on the source posts fetched.",
+  "promptCurated": true
+}

--- a/data/apps/ideabrowser.json
+++ b/data/apps/ideabrowser.json
@@ -5,11 +5,11 @@
   "category": "user-research",
   "subcategory": "curated startup idea database + trend/market research",
   "tagline": "Daily curated startup ideas backed by trend data, market sizing and AI research agents",
-  "priceMonthly": 42,
+  "priceMonthly": 41.58,
   "discontinued": null,
   "pricing": {
     "plan": "Starter",
-    "basis": "annual, billed yearly",
+    "basis": "annual effective per month",
     "unit": "flat",
     "source": "https://www.ideabrowser.com/pricing",
     "checkedOn": "2026-08-10",


### PR DESCRIPTION
Adds Ideabrowser (ideabrowser.com) to the death list.

- verdict: kinda — scraping trend signals and drafting an opportunity brief with an LLM is a one-sitting build, but the accumulated, editorially-curated database of 1,000+ ideas and the trend-signal history are the real moat.
- pricing: Starter $499/yr, Pro $1,499/yr, Empire $2,999/yr, annual-only billing, sourced from ideabrowser.com/pricing, checked 2026-08-10.
- alternatives: IdeaProof as a free searchable idea database.
- includes a runnable one-shot DIY prompt (Next.js + SQLite, Reddit-signal-to-brief generator).

No favicon included yet — happy to add public/icons/ideabrowser.png in a follow-up if needed.