### PR TITLE
Add scite-ai.json for Scite

### DIFF
--- a/data/apps/scite-ai.json
+++ b/data/apps/scite-ai.json
@@ -1,0 +1,45 @@
+{
+  "slug": "scite-ai",
+  "name": "Scite",
+  "domain": "scite.ai",
+  "category": "ai-search",
+  "subcategory": "citation context + academic literature search",
+  "tagline": "Smart Citations that show whether a paper's citations support, contrast or merely mention its claims",
+  "priceMonthly": 20,
+  "discontinued": null,
+  "pricing": {
+    "plan": "Premium",
+    "basis": "monthly",
+    "unit": "flat",
+    "source": "https://scite.ai/pricing",
+    "checkedOn": "2026-08-10",
+    "confidence": "medium",
+    "notes": "Basic is $7.99/mo, Premium is $19.99/mo (or $100/yr), Premium+ is $59.99/mo; academic and student discounts available; enterprise/team pricing is custom.",
+    "native": "19.99 USD",
+    "freeTier": "Free account allows searching the citation database plus one report and one visualization per month, but reports can't be exported."
+  },
+  "verdict": "not really",
+  "verdictConfidence": "high",
+  "verdictSummary": "The AI classification of a citation as supporting, contrasting or mentioning is a solvable NLP task, but the product's real value is the licensed full-text corpus across 40+ publishers plus preprint servers, kept current and cross-referenced at scale. No individual or small team can replicate that data-access moat; a DIY build only works on open-access papers, which is a small fraction of the literature that matters for a lot of fields.",
+  "coreLoopDIY": "Pull open-access full text (arXiv, PubMed Central, bioRxiv) for a paper's cited works, then use an LLM to classify each citing sentence as supporting, contrasting or neutral.",
+  "diyTimeEstimate": "multi-day",
+  "requirements": ["OpenAI/Anthropic API key", "access to open-access full-text sources (arXiv, PMC, bioRxiv)"],
+  "whatYouLose": ["coverage of paywalled publishers (Wiley, Cambridge, Wolters Kluwer, etc.)", "pre-built citation database spanning hundreds of millions of citation statements", "retraction/correction flags sourced from Crossref and PubMed", "browser extension overlay on Google Scholar and journal pages", "reference-check tool for uploaded manuscripts"],
+  "moatTags": ["proprietary-data", "scale-infra"],
+  "moatNotes": "Publisher licensing agreements plus the scale of already-processed citation statements are the actual barrier; the classifier itself is not the hard part.",
+  "whyPeopleStillPay": "Researchers pay for reliable, broad coverage of paywalled literature and for a maintained, cross-checked citation graph rather than re-scraping and re-classifying papers themselves every time.",
+  "priorArt": [
+    { "name": "Semantic Scholar API", "url": "https://www.semanticscholar.org/product/api", "desc": "free API with citation graphs and some citation-intent classification for open-access papers" }
+  ],
+  "alternatives": [
+    { "name": "Semantic Scholar", "url": "https://www.semanticscholar.org", "type": "free", "repo": null, "platforms": ["web"], "desc": "Free academic search engine with citation graphs and TLDR summaries, though without support/contrast classification.", "stars": null, "lastCommit": null, "selfHost": "hosted", "checkedOn": "2026-08-10" },
+    { "name": "CORE", "url": "https://core.ac.uk", "type": "free", "repo": null, "platforms": ["web"], "desc": "Free aggregator of over 200 million open-access research papers with full-text search.", "stars": null, "lastCommit": null, "selfHost": "hosted", "checkedOn": "2026-08-10" }
+  ],
+  "rejectedAlternatives": [],
+  "relatedSlugs": [],
+  "pagePriority": 3,
+  "verifiedOneShot": false,
+  "notes": "Closest honest consolation build only covers open-access literature; paywalled-publisher coverage is the part that can't be cloned.",
+  "prompt": "Build me an open-access citation-context checker as a Next.js app.\nStack: Next.js + TypeScript, SQLite via better-sqlite3, Tailwind. No auth, single user, localhost only.\nCore loop:\n1. A search box where I paste a DOI or arXiv ID; fetch its metadata and reference list via the free Semantic Scholar API (no key needed).\n2. For each citing paper available as open-access full text (via arXiv or PubMed Central APIs), pull the sentence(s) around the citation.\n3. Send each citation sentence to the Anthropic API (key from .env) with a fixed prompt asking it to classify the citation as supporting, contrasting, or mentioning, with a one-line reason.\n4. Show results in a table: citing paper, classification, and the quoted sentence, filterable by classification.\nOut of scope: paywalled-publisher content, browser extension, manuscript reference-check upload, accounts, alerts.\nInclude a README noting this only works for open-access papers and citing papers, unlike a licensed full-text database.",
+  "promptCurated": true
+}

--- a/data/apps/scite-ai.json
+++ b/data/apps/scite-ai.json
@@ -18,7 +18,7 @@
     "native": "19.99 USD",
     "freeTier": "Free account allows searching the citation database plus one report and one visualization per month, but reports can't be exported."
   },
-  "verdict": "not really",
+  "verdict": "no",
   "verdictConfidence": "high",
   "verdictSummary": "The AI classification of a citation as supporting, contrasting or mentioning is a solvable NLP task, but the product's real value is the licensed full-text corpus across 40+ publishers plus preprint servers, kept current and cross-referenced at scale. No individual or small team can replicate that data-access moat; a DIY build only works on open-access papers, which is a small fraction of the literature that matters for a lot of fields.",
   "coreLoopDIY": "Pull open-access full text (arXiv, PubMed Central, bioRxiv) for a paper's cited works, then use an LLM to classify each citing sentence as supporting, contrasting or neutral.",


### PR DESCRIPTION
Adds Scite (scite.ai) to the death list.

- verdict: not really — classifying a citation as supporting/contrasting/mentioning is a solvable NLP task, but the real moat is the licensed full-text corpus across 40+ publishers plus preprint servers, kept current at scale. A DIY build only covers open-access literature.
- pricing: Basic $7.99/mo, Premium $19.99/mo, Premium+ $59.99/mo, sourced from scite.ai/pricing and cross-checked against MIT Press/PMC coverage, checked 2026-08-10.
- alternatives: Semantic Scholar and CORE as free open-access options (no support/contrast classification).
- includes a runnable one-shot DIY prompt (Next.js + SQLite, open-access-only citation classifier).

No favicon included yet — happy to add public/icons/scite-ai.png in a follow-up if needed.