### PR TITLE
fix: resolve repo root with fileURLToPath so validate works on Windows

### DIFF
--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -4,8 +4,9 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { CATEGORIES, MOAT_TAGS, VERDICTS } from '../src/lib/apps.js';
+import { fileURLToPath } from 'node:url';
 
-const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dir = path.join(root, 'data/apps');
 
 const UNITS = ['flat', 'per-seat', 'usage', 'one-time', 'custom'];


### PR DESCRIPTION
`npm run validate` crashes on Windows before reading a single app file:

    Error: ENOENT: no such file or directory, scandir 'C:\C:\...\canivibecodeit\data\apps'

**Cause.** The script resolves the repo root with `new URL(import.meta.url).pathname`.
On Windows that returns a POSIX-style path with a leading slash (`/C:/...`). win32
`path.resolve` treats it as drive-relative and prepends the current drive, producing
the doubled `C:\C:\...`.

**Fix.** `fileURLToPath(import.meta.url)` instead: one import, one line changed. It
returns a proper `C:\...` path on Windows, behaves identically on Linux/macOS, and as
a bonus decodes percent-encoding, so repo paths with spaces or accents don't break
either.

**Why CI never caught it:** the workflow runs on Linux, where `.pathname` happens to
work.

Tested on Windows / Node 22.12.0; no behavior change on Linux.