### PR TITLE
Dither: pattern-fill instead of one fillRect per cell

### DIFF
--- a/public/js/dither.js
+++ b/public/js/dither.js
@@ -94,16 +94,55 @@
     return { ctx, w, h };
   }
 
-  /* Dithered fill: paint cell-by-cell through the Bayer threshold matrix.
-     density 0..1 decides how many cells light up; cell = dot pitch in px.
-     boost(px, py) optionally adds cursor-reactive density per cell. */
+  /* The Bayer matrix is a 4x4 tile, so for a constant density the set of lit
+     cells repeats every 4 cells in both directions. Render that tile once
+     per (color, density, cell size) into a tiny offscreen canvas and reuse
+     it as a fill pattern — one fillRect call paints an arbitrarily large
+     area instead of one fillRect per lit cell (thousands, for a chart-sized
+     fill). This wasn't a JS-speed problem: on a GPU-driver-limited machine,
+     cutting the per-fill cell count ~9x (tested by bumping the cell size)
+     cut a multi-second load freeze by the same proportion — draw-call count
+     itself was the cost, not what the calls did or how often they ran.
+     createPattern tiles from the canvas's own origin, same as the old
+     per-cell loop's absolute cx/cy % 4 lookup, so adjacent fills (e.g. this
+     function's stacked density bands) still line up seamlessly. */
+  const patternCache = new Map();
+  const ditherPattern = (ctx, rgb, density, cell) => {
+    const key = `${rgb.join(',')}|${density}|${cell}`;
+    let pattern = patternCache.get(key);
+    if (pattern) return pattern;
+    const tile = document.createElement('canvas');
+    tile.width = tile.height = cell * 4;
+    const tctx = tile.getContext('2d');
+    tctx.fillStyle = `rgb(${rgb.join(',')})`;
+    for (let cy = 0; cy < 4; cy++) {
+      for (let cx = 0; cx < 4; cx++) {
+        if (BAYER[cy][cx] / 16 < density) tctx.fillRect(cx * cell, cy * cell, cell - 1, cell - 1);
+      }
+    }
+    pattern = ctx.createPattern(tile, 'repeat');
+    patternCache.set(key, pattern);
+    return pattern;
+  };
+
+  /* Dithered fill: paint through the Bayer threshold matrix. density 0..1
+     decides how many cells light up; cell = dot pitch in px. boost(px, py)
+     optionally adds cursor-reactive density per cell — that needs the slow
+     per-cell path since density then varies within the fill, but nothing
+     currently calls this with a boost (the live cursor aura patches its own
+     small region separately via ditherRectBoostOnly below). */
   function ditherRect(ctx, x, y, w, h, rgb, density, cell = 3, boost) {
+    if (!boost) {
+      ctx.fillStyle = ditherPattern(ctx, rgb, density, cell);
+      ctx.fillRect(x, y, w, h);
+      return;
+    }
     ctx.fillStyle = `rgb(${rgb.join(',')})`;
     const x0 = Math.floor(x / cell), x1 = Math.ceil((x + w) / cell);
     const y0 = Math.floor(y / cell), y1 = Math.ceil((y + h) / cell);
     for (let cy = y0; cy < y1; cy++) {
       for (let cx = x0; cx < x1; cx++) {
-        const d = boost ? Math.min(0.96, density + boost(cx * cell, cy * cell)) : density;
+        const d = Math.min(0.96, density + boost(cx * cell, cy * cell));
         if (BAYER[cy & 3][cx & 3] / 16 < d) {
           ctx.fillRect(cx * cell, cy * cell, cell - 1, cell - 1);
         }


### PR DESCRIPTION
## Summary
- `/stats` was hitting a multi-second freeze on load, specific to this page (not `/` or `/sponsor`, which only carry the globe canvas) and specific to a GPU-driver-limited machine — DevTools showed the time sitting almost entirely in "System"/unattributed, not in our own script execution (~60-140ms).
- Diagnostic: bumping the dither cell size (fewer `fillRect` calls) cut the freeze proportionally. That pointed at draw-call *count* as the actual cost, not JS speed or how often the redraw ran — separate from the render-cost work already on `main` (`0978be1`), which reduces *how often* the fill redraws but keeps the same per-cell `fillRect` loop.
- Fix: the Bayer matrix is a 4x4 tile, so for a constant density the lit cells repeat every 4 cells. Render that tile once per `(color, density, cell)` into a tiny offscreen canvas and reuse it as a fill pattern via `createPattern` — one `fillRect` paints the whole area instead of one per lit cell (thousands, for a chart-sized fill). `createPattern` tiles from the canvas's own origin, matching the old loop's absolute `cx/cy % 4` lookup, so adjacent fills still line up seamlessly, and it respects the ambient clip path same as a normal fill.
- The one caller that passes a per-pixel-varying `boost` (the rare "hovered before the entrance animation finished caching a bitmap" fallback) keeps the original per-cell loop, since a static pattern can't represent a moving cursor-reactive density.

## Test plan
- [x] Verified visually identical dither texture (area chart + all three bar charts) before/after
- [x] Verified hover/tooltip and the boost-only aura patch still work
- [x] Confirmed on the reporting machine: load freeze was still present after the render-cost work on `main` alone, resolved after this pattern-fill change