### PR TITLE
fix(validate): resolve the script path with fileURLToPath so validate runs on Windows

### DIFF
--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -3,9 +3,14 @@
    Run with `npm run validate`. No dependencies, on purpose. */
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { CATEGORIES, MOAT_TAGS, VERDICTS } from '../src/lib/apps.js';
 
-const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+// fileURLToPath, not new URL().pathname: on Windows the latter yields "/C:/..."
+// and leaves "%20" in place for a path with spaces, so readdirSync throws ENOENT
+// before a single file is checked. Every app entry arrives as a contributor PR,
+// so this has to run wherever the contributor happens to be.
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dir = path.join(root, 'data/apps');
 
 const UNITS = ['flat', 'per-seat', 'usage', 'one-time', 'custom'];


### PR DESCRIPTION
`npm run validate` can't run on Windows at all right now.

`scripts/validate-apps.mjs` resolves its own location with:

```js
const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
```

On Windows, `new URL(import.meta.url).pathname` returns `/C:/Users/...` — a leading
slash before the drive letter — and leaves `%20` in place when the checkout path
contains a space. `readdirSync` then throws before a single file is checked:

```
Error: ENOENT: no such file or directory, scandir
  'C:\C:\Users\...\bug%20hunting\canivibecodeit\data\apps'
```

`fileURLToPath()` is the documented way to convert a `file:` URL to a path and handles
both the drive letter and the percent-decoding.

**Scope:** one line plus the import. No behaviour change on Linux or macOS — CI is
unaffected, since `new URL().pathname` already returns a usable POSIX path there. This
only unblocks contributors on Windows.

**Verified:** `npm run validate` now completes on Windows 11 / Node 25 against the
current data set — `✓ 996 app files pass`.

I found this while reading the repo, so it seemed worth sending back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)