### PR TITLE
fix: three input-validation gaps (priorArt url scheme, timingSafeEqual byte length, multipart bodies)

### DIFF
--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -164,10 +164,15 @@ for (const file of files) {
     bad('discontinued must be a non-empty string or null');
   }
 
+  // The url lands in an href on the app page, so it gets the same scheme
+  // allowlist as every other URL field here. The angle-bracket scan above does
+  // not catch "javascript:" — it carries no "<" or ">".
   if (Array.isArray(app.priorArt)) {
     app.priorArt.forEach((p, i) => {
       if (!p || typeof p !== 'object' || !isStr(p.name) || !isStr(p.url)) {
         bad(`priorArt[${i}] needs a name and a url`);
+      } else if (!/^https?:\/\//.test(p.url)) {
+        bad(`priorArt[${i}].url must be an http(s) URL`);
       }
     });
   }

--- a/src/lib/sponsors.js
+++ b/src/lib/sponsors.js
@@ -222,13 +222,22 @@ export function signAction(id, action) {
 
 export function verifyAction(id, action, sig) {
   const expected = signAction(id, action);
-  if (!expected || typeof sig !== 'string' || sig.length !== expected.length) return false;
-  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+  if (!expected || typeof sig !== 'string') return false;
+  return timingSafeMatch(sig, expected);
 }
 
+/* Byte length, never string length. A JS string length counts UTF-16 code
+   units while the Buffers below are UTF-8, so a value carrying any multi-byte
+   character passes an a.length === b.length guard with buffers of different
+   sizes — and timingSafeEqual THROWS on a size mismatch rather than returning
+   false. Callers don't catch that, so the request 500s instead of 404ing, and
+   on the admin token the 404/500 split leaks its exact length to anyone who
+   asks. Same shape as the origin check in middleware.js. */
 export function timingSafeMatch(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length || !a) return false;
-  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  if (typeof a !== 'string' || typeof b !== 'string' || !a) return false;
+  const got = Buffer.from(a);
+  const want = Buffer.from(b);
+  return got.length === want.length && crypto.timingSafeEqual(got, want);
 }
 
 export function isAdmin(token) {

--- a/src/lib/stripe.js
+++ b/src/lib/stripe.js
@@ -166,9 +166,13 @@ export function verifyStripeSignature(rawBody, header, secret) {
     .createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');
-  return candidates.some(
-    (sig) =>
-      sig.length === expected.length &&
-      crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
-  );
+  // Byte length, not string length: the header is attacker-suppliable, and a
+  // v1= value of multi-byte characters matches the 64-char digest on string
+  // length while its buffer is twice the size. timingSafeEqual throws on that
+  // mismatch, which would 500 the webhook instead of rejecting the delivery.
+  const want = Buffer.from(expected);
+  return candidates.some((sig) => {
+    const got = Buffer.from(sig);
+    return got.length === want.length && crypto.timingSafeEqual(got, want);
+  });
 }

--- a/src/pages/api/sponsor.js
+++ b/src/pages/api/sponsor.js
@@ -16,9 +16,13 @@ export async function POST({ request, clientAddress }) {
 
   if (body.website) return json({ ok: true });
 
-  const email = body.email?.trim().toLowerCase();
+  // Coerced, not assumed: readBody falls through to formData() for anything
+  // that isn't JSON, and a multipart file part arrives as a File. It has no
+  // .trim (throws past the try/catch above), and its .slice returns a Blob the
+  // driver can't bind.
+  const email = String(body.email ?? '').trim().toLowerCase();
   if (!validEmail(email)) return json({ error: 'invalid email' }, 400);
 
-  await addSponsorInquiry(email, body.message);
+  await addSponsorInquiry(email, typeof body.message === 'string' ? body.message : null);
   return json({ ok: true });
 }

--- a/src/pages/api/waitlist.js
+++ b/src/pages/api/waitlist.js
@@ -30,7 +30,10 @@ export async function POST({ request, clientAddress }) {
   // Honeypot: bots fill every field. Pretend success, store nothing.
   if (body.website) return json({ ok: true });
 
-  const email = body.email?.trim().toLowerCase();
+  // Coerced, not assumed: readBody falls through to formData() for anything
+  // that isn't JSON, and a multipart file part arrives as a File — which has
+  // no .trim, so the bare call throws past this endpoint's try/catch.
+  const email = String(body.email ?? '').trim().toLowerCase();
   if (!validEmail(email) || unreachable(email)) return json({ error: 'invalid email' }, 400);
 
   const source = SOURCES.includes(body.source) ? body.source : 'unknown';


### PR DESCRIPTION
Three small hardening fixes found while reading through the repo. All low severity, all
one-liners, and in each case the codebase already does the right thing somewhere else —
these are the spots where that pattern just isn't applied.

Sending them as a normal PR rather than through private disclosure: none of them hands
anyone a working exploit against the live site, and the repo has private vulnerability
reporting turned off. Happy to move this to a private channel if you'd rather — just say
so and I'll close it.

---

### 1. `priorArt[].url` isn't scheme-checked, and it's rendered into an `href`

`scripts/validate-apps.mjs` enforces `^https?://` on `alternatives[].url`,
`rejectedAlternatives[].url`, `pricing.priceChanges[].source` and `facts.sources[]`.
`priorArt[].url` only gets `isStr`:

```js
if (!p || typeof p !== 'object' || !isStr(p.name) || !isStr(p.url)) {
  bad(`priorArt[${i}] needs a name and a url`);
}
```

It reaches an href unchanged at `src/pages/[slug].astro:308`:

```astro
<a class="prior-card" href={p.url}>
```

The `scanAngles` pass doesn't cover this — a `javascript:` URL contains no `<` or `>`, so
it goes through. Since every app entry arrives as a PR, the validator is the half of that
review that doesn't get tired, and this is one field it isn't looking at.

Practically it's bounded: it needs a merged PR, a `javascript:` href needs a click rather
than firing on load, session cookies are httpOnly, and CSP blocks it outright wherever
`CSP_ENFORCE` is set. Still, the fix is the same line you already use four times.

### 2. `timingSafeEqual` gets mismatched buffers on multi-byte input

`timingSafeMatch`, `verifyAction` and `verifyStripeSignature` all compare **string**
length and then pass the values to `timingSafeEqual` as **UTF-8 buffers**:

```js
if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length || !a) return false;
return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
```

A JS string length counts UTF-16 code units, so a value with any multi-byte character can
satisfy `a.length === b.length` while the buffers differ in size — and `timingSafeEqual`
throws `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH` on that rather than returning `false`. No
call site catches it, so a failed comparison 500s instead of returning the 404 the admin
page intends. The same input class 500s the Stripe webhook through a crafted
`Stripe-Signature` header.

`src/middleware.js` already handles exactly this, with a comment explaining why:

```js
const a = Buffer.from(got, 'latin1');
const b = Buffer.from(secret, 'utf8');
if (a.length === b.length && timingSafeEqual(a, b)) return 'ok';
```

This applies that same shape in the other three places.

### 3. A multipart body reaches `.trim()` as a `File`

`readBody()` falls through to `request.formData()` for anything that isn't JSON, and a
file part comes back as a `File`, not a string. `api/waitlist.js` and `api/sponsor.js`
then call:

```js
const email = body.email?.trim().toLowerCase();
```

`File` has no `.trim`, and the surrounding `try/catch` only wraps `readBody()`, so the
`TypeError` escapes and the request 500s. `api/sponsor.js` has the same issue one line
down, where `addSponsorInquiry` does `message?.slice(0, 2000)` — on a `File` that returns
a `Blob` the driver can't bind.

`api/search.js` (`typeof body.q === 'string'`) and `api/sponsor/details.js`
(`String(body.t ?? '')`) already do this correctly.

---

### Verification

- All **996** existing app files still pass `validate` — the new `priorArt` rule doesn't
  reject anything already in the tree.
- An entry with a `javascript:` `priorArt` url is now rejected:
  `priorArt[0].url must be an http(s) URL`.
- Multi-byte input to all three comparison functions returns `false` instead of throwing.
- A genuine Stripe signature and a correct admin token are both still accepted — I checked
  for regressions specifically, since these guard live paths.

Note: `npm run validate` currently can't run on Windows at all (`new URL(import.meta.url).pathname`
yields `/C:/...`). That's unrelated to security so I sent it separately as #185; this
branch leaves that line alone to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)