### PR TITLE
Agent-addressable verdicts: llms.txt, /api/verdicts index, single-app lookup, recent feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ as important — what you lose by leaving. Think caniuse.com, but for killing yo
 
 Yes, [you can vibecode this site too](https://canivibecodeit.com/vibecode-this-site).
 
+## For agents
+
+The site is agent-addressable. No auth, no tracking, plain JSON:
+
+- `https://canivibecodeit.com/llms.txt` — site map for LLMs
+- `https://canivibecodeit.com/api/verdicts` — full verdict index (slug, name, verdict, category, price, votes)
+- `https://canivibecodeit.com/api/verdicts/<slug>` — one app: verdict, replacement prompt, moats, pricing
+- `https://canivibecodeit.com/api/recent` — verdicts added in the last 7 days
+
+Any Hermes Agent (or Claude Code, Codex, etc.) can check "what's the verdict on X" and cite it.
+
 ## Add an app
 
 Apps are JSON files in [`data/apps/`](data/apps) — one file per app, contributed by PR.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,31 @@
+# Can I Vibecode It?
+
+> Find out which paid SaaS subscriptions are one AI prompt away from free. Honest verdicts on 1,093 apps: can one AI coding agent rebuild it in one session (YES), in a weekend (KINDA), or does the moat survive (NOT REALLY)? Each entry carries the exact replacement prompt, what you lose by leaving, and the moats that keep it alive.
+
+## Sections
+
+- [All app verdicts](https://canivibecodeit.com/): every app, ranked by "I replaced this" votes
+- [Moats](https://canivibecodeit.com/moats): why the surviving apps survive
+- [Moat tags](https://canivibecodeit.com/moat/network-effect): e.g. /moat/network-effect, /moat/execution-polish, /moat/proprietary-data
+- [Categories](https://canivibecodeit.com/categories): verdicts grouped by category
+- [Stats](https://canivibecodeit.com/stats): aggregate numbers
+- [Builds](https://canivibecodeit.com/post-a-build): what people actually vibe coded, with the exact prompts
+- [Alternatives](https://canivibecodeit.com/alternatives): products adjacent to these apps
+
+## Machine-readable API
+
+- `GET /api/verdicts` — full JSON index of every app: slug, name, verdict, category, subcategory, priceMonthly, votes, url.
+- `GET /api/verdicts/{slug}` — one app (e.g. /api/verdicts/notion): verdict, replacement prompt, what you lose, moat tags, pricing details.
+- `GET /api/recent` — verdicts added in the last 7 days (newest first).
+
+## Verdict legend
+
+- YES — one AI session rebuilds a usable personal version; no moat in the way.
+- KINDA — buildable in a weekend; real gaps remain.
+- NOT REALLY — the value is the network, the data, or the infra; the moat survives.
+
+## Data
+
+- MIT-licensed. One JSON file per app in `data/apps/<slug>.json` at https://github.com/canivibecodeit/canivibecodeit
+- Pricing is checked against each app's pricing page and carries a confidence level and check date.
+- Verdicts are added daily; thousands more on the way.

--- a/src/pages/api/recent.js
+++ b/src/pages/api/recent.js
@@ -1,0 +1,21 @@
+/* Recent verdicts (last 7 days) for agents and feeds.
+   GET /api/recent — reads the build-time generated list
+   (scripts/recent-verdicts.mjs, git-log based: data/apps files added
+   in the last 7 days). Empty when the generator has not run (fresh clone). */
+import { readFileSync } from 'node:fs';
+import { json } from '../../lib/request.js';
+
+export function GET() {
+  let apps = [];
+  try {
+    apps = JSON.parse(readFileSync('src/generated/recent.json', 'utf8'));
+  } catch {
+    // not built yet — empty list is a valid response
+  }
+  return json({
+    count: apps.length,
+    window: 'last 7 days (git history of data/apps)',
+    note: 'empty when the build-time generator has not run',
+    apps,
+  });
+}

--- a/src/pages/api/verdicts.js
+++ b/src/pages/api/verdicts.js
@@ -1,0 +1,40 @@
+/* Machine-readable verdict index for agents.
+   GET /api/verdicts -> every app as compact JSON.
+   No auth, no writes, no tracking: agents can rely on it. */
+import { allApps } from '../../lib/apps.js';
+import { voteCounts } from '../../lib/db.js';
+import { json } from '../../lib/request.js';
+
+const ORDER = { yes: 0, kinda: 1, no: 2 };
+
+export async function GET() {
+  const votes = await voteCounts();
+  const apps = allApps()
+    .map((a) => ({
+      slug: a.slug,
+      name: a.name,
+      verdict: a.verdict,
+      verdictConfidence: a.verdictConfidence ?? null,
+      category: a.category,
+      subcategory: a.subcategory ?? null,
+      priceMonthly: a.priceMonthly ?? null,
+      votes: votes(a.slug),
+      url: `https://canivibecodeit.com/${a.slug}`,
+    }))
+    .sort(
+      (a, b) =>
+        (ORDER[a.verdict] ?? 9) - (ORDER[b.verdict] ?? 9) ||
+        b.votes - a.votes ||
+        a.name.localeCompare(b.name)
+    );
+  return json({
+    total: apps.length,
+    generatedAt: new Date().toISOString(),
+    legend: {
+      yes: 'one AI session rebuilds a usable personal version; no moat in the way',
+      kinda: 'buildable in a weekend; real gaps remain',
+      no: 'the value is the network, the data, or the infra; the moat survives',
+    },
+    apps,
+  });
+}

--- a/src/pages/api/verdicts/[slug].js
+++ b/src/pages/api/verdicts/[slug].js
@@ -1,0 +1,36 @@
+/* Single-app verdict lookup for agents.
+   GET /api/verdicts/{slug} -> one app, full detail. */
+import { getApp } from '../../../lib/apps.js';
+import { voteCount } from '../../../lib/db.js';
+import { json } from '../../../lib/request.js';
+
+export async function GET({ params }) {
+  const app = getApp(params.slug);
+  if (!app) return json({ error: 'not found' }, 404);
+  const votes = await voteCount(app.slug);
+  return json({
+    slug: app.slug,
+    name: app.name,
+    domain: app.domain ?? null,
+    tagline: app.tagline ?? null,
+    category: app.category,
+    subcategory: app.subcategory ?? null,
+    verdict: app.verdict,
+    verdictConfidence: app.verdictConfidence ?? null,
+    verdictSummary: app.verdictSummary ?? null,
+    coreLoopDIY: app.coreLoopDIY ?? null,
+    diyTimeEstimate: app.diyTimeEstimate ?? null,
+    requirements: app.requirements ?? [],
+    whatYouLose: app.whatYouLose ?? [],
+    moatTags: app.moatTags ?? [],
+    moatNotes: app.moatNotes ?? null,
+    whyPeopleStillPay: app.whyPeopleStillPay ?? null,
+    priceMonthly: app.priceMonthly ?? null,
+    pricing: app.pricing ?? null,
+    prompt: app.prompt ?? null,
+    promptCurated: app.promptCurated ?? false,
+    verifiedOneShot: app.verifiedOneShot ?? false,
+    votes,
+    url: `https://canivibecodeit.com/${app.slug}`,
+  });
+}


### PR DESCRIPTION
Makes the site directly usable by AI agents (Hermes Agent, Claude Code, Codex, etc.) with no auth and no tracking.

**Adds**
- `public/llms.txt` — LLM site map: sections, verdict legend, API docs
- `GET /api/verdicts` — full JSON index of all apps (slug, name, verdict, verdictConfidence, category, subcategory, priceMonthly, votes, url), sorted yes → kinda → no, then by votes
- `GET /api/verdicts/:slug` — one app: verdict + summary, replacement prompt, requirements, whatYouLose, moat tags, pricing detail; 404 for unknown slugs
- `GET /api/recent` — last-7-days verdicts from the existing build-time generator
- README `For agents` section

**Why**
The verdict data is MIT-licensed and in plain JSON files already; this just exposes it in the shape agents expect (llms.txt + tiny JSON API). An agent can now answer "what's the verdict on X" and cite it, which is exactly what the site's own agent-driven submit flow implies.

**Verified**
- `npm run build` passes
- Local server: /llms.txt → 200; /api/verdicts → total 1093, sorted, votes included; /api/verdicts/1of10 → full prompt + moatTags; unknown slug → 404; /api/recent → valid JSON (count reflects clone depth locally; real history yields true 7-day delta)

No writes, no auth, no analytics changes.