### PR TITLE
README: update the .env.example description

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm start          # node server on 127.0.0.1:8095
 ```
 
 No environment variables are required for local development. `.env.example` documents
-the optional ones (analytics key, data directory).
+the optional ones (analytics, sign-in, payments, email, media storage).
 
 ## Stack
 


### PR DESCRIPTION
The line about optional environment variables still says `.env.example` covers an analytics key and the data directory. It now documents 33 variables across analytics, sign-in, payments, email, and media storage — this updates the parenthetical to match.

Docs-only; no build inputs touched.