### PR TITLE
Tower: entry describes an AI coding assistant, not a Git client

### DIFF
--- a/data/apps/tower.json
+++ b/data/apps/tower.json
@@ -57,7 +57,7 @@
   "verdict": "yes",
   "verdictConfidence": "medium",
   "verdictSummary": "Tower's solo core is compact: build a repository-local Git client assistant that indexes one codebase, calls one model, proposes diffs, runs tests, and records every change. A competent builder can reach a useful personal version in one sitting, while the paid product mainly wins on model, context, integration.",
-  "coreLoopDIY": "Build a repository-local Git client assistant that indexes one codebase, calls one model, proposes diffs, runs tests, and records every change.",
+  "coreLoopDIY": "Drive everyday Git from a native window: history, staging, branches and remotes, with every destructive action undoable.",
   "diyTimeEstimate": "one sitting",
   "replacementScope": "personal replacement for the core loop",
   "requirements": [
@@ -66,17 +66,17 @@
     "OpenAI API key in .env"
   ],
   "whatYouLose": [
-    "large-context infrastructure",
-    "IDE-wide polish and latency",
-    "enterprise policy, telemetry, and support",
-    "frontier coding model quality"
+    "Windows, and years of polish on both platforms",
+    "a three-way merge conflict editor",
+    "submodule and Git LFS support that behaves",
+    "hosting service integrations and paid support"
   ],
   "moatTags": [
-    "proprietary-models",
-    "execution-polish"
+    "execution-polish",
+    "integrations"
   ],
   "moatNotes": "model/context/integration",
-  "whyPeopleStillPay": "Tower: Developers pay for reliable context assembly, fast models, editor integration, evaluations, and safe handling of complex repositories.",
+  "whyPeopleStillPay": "Developers pay for a client that stays fast on a huge repository, makes dangerous operations reversible, and is supported when it goes wrong.",
   "ongoingBurden": "Maintain model adapters, token budgets, indexing, sandboxing, diff application, test runners, and editor integrations.",
   "priorArt": [
     {
@@ -314,6 +314,6 @@
   "pagePriority": 3,
   "verifiedOneShot": false,
   "notes": "Strong page because Tower separates a compact personal workflow from the value of long-term polish.",
-  "prompt": "Build a usable personal replacement for the core loop of Tower.\nUse exactly this stack: Python 3.12 + Typer + SQLite.\nPrimary job: Build a repository-local Git client assistant that indexes one codebase, calls one model, proposes diffs, runs tests, and records every change.\nStart from an empty folder and create the complete working project.\nMake the default mode single-user and private.\nStore user data locally unless the core job requires the declared self-hosted database.\nDo not add analytics, telemetry, ads, or third-party accounts.\nPut every secret and external credential in .env and provide .env.example.\nUse realistic sample data that is clearly labelled and easy to delete.\nImplement the smallest polished interface that completes the core loop end to end.\nInclude clear empty, loading, validation, success, and failure states.\nAdd import and export so the user is not trapped in the app.\nUse accessible keyboard navigation, labels, focus states, and sensible contrast.\nValidate untrusted input and never log secrets or private file contents.\nDeliberately exclude these paid-product advantages: large-context infrastructure; IDE-wide polish and latency; enterprise policy, telemetry, and support.\nDo not fake integrations, network effects, proprietary data, model quality, compliance, or security claims.\nWhere an external API is optional, keep the app useful without it and explain the degraded mode.\nWrite focused unit tests for the data model and the most important workflow.\nAdd one end-to-end smoke test that proves the core loop works.\nCreate a README with setup, permissions, architecture, data location, backup, and limitations.\nAdd scripts for install, development, test, build, and a production-style local run.\nRun the tests and build before finishing, then fix errors rather than merely describing them.",
+  "prompt": "Build me a native Git client for macOS to replace Tower.\nUse exactly this stack: Swift 6 + SwiftUI + libgit2 through SwiftGit2; no alternative stacks.\nPrimary job: run the everyday Git loop in a real window · history, staging, branches, remotes · and make every destructive action undoable.\nStart from an empty folder and create the complete working project.\nA three pane window: repositories on the left, history in the middle, the selected commit or the working copy on the right.\nHistory shows the commit graph with lanes, author, date and refs, and stays responsive on a repository with 50k commits by loading in pages.\nStaging works by file and by hunk, with a side by side diff and syntax highlighting through Highlightr.\nAn undo stack is the point of this build: every action that changes refs records how to reverse itself, and Cmd+Z walks it back. Commit, checkout, branch delete, merge, stash and reset all participate.\nUndo is implemented over the reflog rather than a private log, so a reversal still works after the app has been quit and reopened.\nDrag a branch onto another to merge, with a confirmation sheet naming both branches and the strategy.\nRemotes: fetch, pull, push, and a clearly marked force push behind a second confirmation that types out the branch name.\nUse the credentials git already has via the system keychain; never prompt for or store a password.\nDo not add analytics, telemetry, accounts, or a hosted service.\nInclude clear empty, loading, success and recoverable error states, including a repository with no commits and a detached HEAD.\nWrite focused unit tests for the undo stack and the hunk staging logic.\nAdd one end-to-end smoke test that commits, deletes a branch, undoes both, and asserts the refs are back.\nCreate a README with setup, keyboard shortcuts, and limitations.\nDeliberately out of scope: Windows, a three-way merge conflict editor, Git LFS, and submodule management.\nRun the tests and build before finishing, then fix errors rather than describing them.",
   "promptCurated": false
 }


### PR DESCRIPTION
## The problem

`data/apps/tower.json` describes a different product, and the giveaway is that it does so in **exactly the same words** as `data/apps/gitkraken.json`.

Both files contain this sentence, identical, as `coreLoopDIY` and as the prompt's `Primary job:`

```
Build a repository-local Git client assistant that indexes one codebase,
calls one model, proposes diffs, runs tests, and records every change.
```

Tower is a native Git client for Mac and Windows. It indexes nothing and calls no model.

`whatYouLose` follows the same template ("frontier coding model quality", "large-context infrastructure", "IDE-wide polish and latency"), `whyPeopleStillPay` says developers pay for "reliable context assembly, fast models, editor integration, evaluations", and `moatTags` carries `proprietary-models`.

## The fix

A prompt for what Tower actually is: a native macOS client in Swift and SwiftUI over libgit2.

The build is organised around an **undo stack implemented over the reflog**, since reversible mistakes are what Tower is known for, and doing it over the reflog rather than a private log means an undo still works after quitting the app. Force push sits behind a confirmation that makes you type the branch name.

`whatYouLose` now names the real losses: Windows, the three-way merge editor, submodules and LFS, hosting integrations and support. `moatTags` becomes `execution-polish` and `integrations`.

**Deliberately different from the GitKraken PR.** GitKraken gets a Go and bubbletea terminal client built around the commit graph. Shipping one shared prompt to two products is what caused this bug, so the fixes do not share one either.

## Verifying

```sh
diff <(git show main:data/apps/tower.json) <(git show main:data/apps/gitkraken.json) | grep "calls one model"
npm run validate
```

`npm run validate` passes on 1093 files.

## Context

Found while building a German adaptation of this project, which credits it and keeps the MIT licence. Pricing and every other field were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFevh93J66VXKDtjMJRv13