### PR TITLE
Fantastical: prompt builds a Calendly booking service, not a calendar client

### DIFF
--- a/data/apps/fantastical.json
+++ b/data/apps/fantastical.json
@@ -65,7 +65,7 @@
   "verdict": "yes",
   "verdictConfidence": "high",
   "verdictSummary": "The core loop is small enough for a capable coding agent to produce a useful local version in one sitting. For Fantastical, create a polished Apple calendar client with natural-language event entry and local sets. The hard boundary is native apple integrations, widgets, sync, proposals, and years of calendar edge cases, plus calendar integrations and reliability.",
-  "coreLoopDIY": "Build a polished Apple calendar client with natural-language event entry and local calendar sets, create conflict-safe events, and send confirmations and reminders.",
+  "coreLoopDIY": "Type an event in plain language, see how it was understood, confirm, and have it land in the calendar you already use.",
   "diyTimeEstimate": "multi-day",
   "requirements": [
     "Google Calendar OAuth credentials",
@@ -77,8 +77,8 @@
   "whatYouLose": [
     "native Apple integrations, widgets, sync, proposals, and years of calendar edge cases",
     "multiple calendar providers",
-    "team routing and round-robin",
-    "payments",
+    "a real month and week grid you can drag events around in",
+    "travel time, weather and conference call detection",
     "timezone edge-case maturity"
   ],
   "moatTags": [
@@ -122,6 +122,6 @@
   "pagePriority": 5,
   "verifiedOneShot": false,
   "notes": "Editorial comparison targets the Premium Individual plan and a single-user booking service DIY substitute. Recheck price before merge.",
-  "prompt": "Build a personal replacement for Fantastical in an empty repository.\nUse Next.js 15, TypeScript, PostgreSQL, Drizzle ORM, Google Calendar OAuth, and Resend; do not offer alternative stacks.\nThe core loop is: build a polished Apple calendar client with natural-language event entry and local calendar sets, create conflict-safe events, and send confirmations and reminders.\nMake the first run work locally with one documented command.\nStore all user data locally by default and make export straightforward.\nPut secrets in .env, ship .env.example, and never commit credentials.\nImplement one account with configurable working hours, buffers, minimum notice, and booking horizon.\nConnect Google Calendar using OAuth and store refresh tokens encrypted at rest.\nCalculate availability in UTC and render it in the visitor's detected timezone.\nReserve slots transactionally, create calendar events, and prevent concurrent double booking.\nSend confirmation, cancellation, and reminder email with signed management links.\nAdd an admin booking list, event-type editor, audit log, and calendar reconnect flow.\nInclude clear empty, loading, success, and recoverable error states.\nAdd input validation, safe filenames, and graceful handling of unavailable APIs.\nWrite focused tests for the core transformation and one end-to-end happy path.\nCreate a README with setup, architecture, permissions, data location, and backup steps.\nDo not add accounts, billing, telemetry, analytics, or a hosted control plane.\nDeliberately leave out Microsoft and Apple calendar support.\nDeliberately leave out team round-robin routing.\nDeliberately leave out payments, CRM workflows, and enterprise controls.\nFinish by running the tests and listing the exact commands used.",
+  "prompt": "Build me a natural-language quick-entry tool for my calendar, to replace Fantastical.\nUse exactly this stack: Node 22 + TypeScript + chrono-node for parsing + tsdav for CalDAV; no alternative stacks.\nPrimary job: type \"dentist tuesday 2:30 to 3:15\" and have a real event appear in the calendar I already own, after I have seen how the sentence was read.\nStart from an empty folder and create the complete working project.\nA command quick \"...\" parses date, start, duration, location after \"at\" or \"in\", and a calendar picked with /work or /personal.\nAlways print the parsed result as a plain sentence and wait for confirmation before writing. A quick-entry tool that guesses silently is worse than a form.\nWarn when the new event overlaps an existing one, and name what it collides with.\nConnect over CalDAV to iCloud or Google using an app password from .env. The provider calendar stays the single source of truth · keep no local event database.\nA command agenda prints today and tomorrow as a compact list.\nRecurrence for the cases people actually type: every monday, every other week, first friday of the month. Anything more exotic is refused with a clear message rather than guessed.\nHandle the timezone honestly: parse in the local zone, store in UTC, and show the zone in the confirmation line whenever it differs from the machine.\nA menu bar window with a single input field is the finishing touch. Build it after the CLI works, with Tauri.\nDo not add accounts, telemetry, or a hosted service.\nInclude clear empty, loading, success and recoverable error states, especially when CalDAV is unreachable.\nWrite focused tests for the parser: relative days, times without minutes, ranges, and the recurrence cases above.\nCreate a README with CalDAV setup for iCloud and Google, and the parser's known limits.\nDeliberately out of scope: a month grid view, invitations and attendee management, and any booking page for other people.\nRun the tests and build before finishing, then fix errors rather than describing them.",
   "promptCurated": false
 }


### PR DESCRIPTION
## The problem

`data/apps/fantastical.json` builds a booking service. Fantastical is a calendar client.

`coreLoopDIY` starts correctly and then drifts:

```
...create conflict-safe events, and send confirmations and reminders.
```

The prompt on `main` commits to it fully:

```
Implement one account with configurable working hours, buffers, minimum notice, and booking horizon.
Calculate availability in UTC and render it in the visitor's detected timezone.
Reserve slots transactionally, create calendar events, and prevent concurrent double booking.
Send confirmation, cancellation, and reminder email with signed management links.
Add an admin booking list, event-type editor, audit log, and calendar reconnect flow.
```

A calendar client has no visitors, no slots and no booking horizon. `whatYouLose` carries the same template, claiming you give up "team routing and round-robin" and "payments".

## The fix

A prompt for what people actually buy Fantastical for: natural-language quick entry into a calendar they already own. Node, TypeScript, chrono-node for parsing, tsdav for CalDAV.

Two decisions worth flagging:

- **The parse is always shown before anything is written.** A quick-entry tool that guesses silently is worse than a form, and this is where these tools are won or lost.
- **Recurrence is limited on purpose** to the cases people type ("every other week", "first friday of the month"). Anything more exotic is refused with a message rather than guessed wrong.

`whatYouLose` now names real losses: a month and week grid you can drag events around in, travel time and weather detection, the native widgets. `verdict: "yes"` and `diyTimeEstimate: "multi-day"` are unchanged and look right for this scope.

## Verifying

```sh
git show main:data/apps/fantastical.json | grep -E "booking horizon|double booking|round-robin"
npm run validate
```

`npm run validate` passes on 1093 files.

## Context

Found while building a German adaptation of this project, which credits it and keeps the MIT licence. Pricing was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFevh93J66VXKDtjMJRv13
