### PR TITLE
BazQux Reader: whatYouLose and whyPeopleStillPay describe a reference manager

### DIFF
--- a/data/apps/bazqux-reader.json
+++ b/data/apps/bazqux-reader.json
@@ -75,17 +75,17 @@
     "optional OpenAI API key stored in .env"
   ],
   "whatYouLose": [
-    "team libraries and institutional access",
-    "resilient polling of malformed and rate-limited feeds",
-    "licensed scholarly metadata",
-    "publisher-specific import reliability",
-    "citation graph scale"
+    "polling thousands of feeds reliably, including malformed and rate-limited ones",
+    "comment threads pulled in from the sites you follow",
+    "full-text extraction for feeds that only publish an excerpt",
+    "search across years of archived items",
+    "sync with the reader apps you use on a phone"
   ],
   "moatTags": [
     "execution-polish"
   ],
   "moatNotes": "data/import reliability",
-  "whyPeopleStillPay": "BazQux Reader: Researchers pay for correct metadata, resilient importers, citation coverage, and workflows that survive publisher and browser changes.",
+  "whyPeopleStillPay": "BazQux Reader: people pay for a fetcher that keeps working. Feeds break, sites rate-limit, and someone else keeps the pipeline honest so the unread count can be trusted.",
   "ongoingBurden": "Maintain parsers, deduplication, PDF extraction, citation styles, and legal access boundaries.",
   "priorArt": [
     {


### PR DESCRIPTION
## The problem

The tagline, `coreLoopDIY` and the prompt in `data/apps/bazqux-reader.json` are all correct. Two fields underneath describe a reference manager.

From `main`:

```
"whatYouLose": ["team libraries and institutional access",
                "licensed scholarly metadata",
                "publisher-specific import reliability",
                "citation graph scale", ...]

"whyPeopleStillPay": "BazQux Reader: Researchers pay for correct metadata,
resilient importers, citation coverage, and workflows that survive publisher
and browser changes."
```

That is Zotero or Mendeley. BazQux is an RSS reader: it has no citation graph and licenses no scholarly metadata.

The same "licensed scholarly metadata" and "citation graph scale" wording also appears in `data/apps/feedbin.json` and `data/apps/glasp.json`, both also reading tools, so it looks like one template that landed on several entries. I have only touched this one, per "one app per PR".

## The fix

`whatYouLose` now names what a feed reader actually gives up: polling thousands of feeds including the malformed and rate-limited ones, the comment threads BazQux is specifically known for, full-text extraction for excerpt-only feeds, search across years of archive, and sync with phone reader apps.

`whyPeopleStillPay` says the honest thing: you pay for a fetcher that keeps working, so the unread count can be trusted.

## Scope

Only those two fields. The prompt, verdict and pricing are untouched.

`npm run validate` passes on 1093 files.

## Context

Found while building a German adaptation of this project, which credits it and keeps the MIT licence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFevh93J66VXKDtjMJRv13
